### PR TITLE
Source list in live context

### DIFF
--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -101,7 +101,7 @@ Step 1: Prepare The Install Environment
 
 #. Setup and update the repositories::
 
-     sudo vi /mnt/etc/apt/sources.list
+     sudo vi /etc/apt/sources.list
 
    .. code-block:: sourceslist
 


### PR DESCRIPTION
Line 104 : "/mnt/etc/apt/sources.list" should be  "/etc/apt/sources.list", we are preparing the live context, not the chroot context, yet.