### PR TITLE
Man pages: generate cross-hyperlinks

### DIFF
--- a/scripts/man_pages.py
+++ b/scripts/man_pages.py
@@ -44,7 +44,7 @@ man_section_name = 'Man Pages'
 
 build_dir = '_build/man'
 
-regex_template = ('<a(?P<href_place> )class=\"Xr\">%s'
+regex_template = ('<a(?P<href_place> )class=\"Xr\"(?P<title>.*?)>%s'
                   '\((?P<num>[1-9])\)<\/a>')
 final_regex = ('<a href="../\g<num>/\g<name>.\g<num>.html" class="Xr"'
                '>\g<name>(\g<num>)</a>')

--- a/scripts/man_pages.py
+++ b/scripts/man_pages.py
@@ -53,7 +53,8 @@ final_regex = ('<a href="../\g<num>/\g<name>.\g<num>.html" class="Xr"'
 def add_hyperlinks(out_dir, pages):
     all_pages = []
     for _section, section_pages in pages.items():
-        all_pages.extend([page.split('.')[0] for page in section_pages])
+        all_pages.extend([
+            os.path.splitext(page)[0] for page in section_pages])
     tmp_regex = '(?P<name>' + "|".join(all_pages) + ')'
     html_regex = re.compile(regex_template % tmp_regex, flags=re.MULTILINE)
 


### PR DESCRIPTION
Use regex as an easy method to patch text.

Generated example: https://gmelikov.github.io/openzfs-docs/man/8/zfs.8.html

Signed-off-by: George Melikov <mail@gmelikov.ru>