### PR TITLE
Fix Ubuntu 20.04 download link.

### DIFF
--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
@@ -161,7 +161,7 @@ System Requirements
 ~~~~~~~~~~~~~~~~~~~
 
 - `Ubuntu 20.04 (“Focal”) Desktop CD
-  <http://releases.ubuntu.com/18.04.3/ubuntu-18.04.3-desktop-amd64.iso>`__
+  <http://releases.ubuntu.com/20.04/ubuntu-20.04-desktop-amd64.iso>`__
   (*not* any server images)
 - Installing on a drive which presents 4 KiB logical sectors (a “4Kn” drive)
   only works with UEFI booting. This not unique to ZFS. `GRUB does not and


### PR DESCRIPTION
This fixes the Ubuntu 20.04 Root on ZFS docs pointing to the Desktop 18.04.3 ISO. I left as http though the link is also available over https. cc @rlaager 

Signed-off-by: Cory Stephenson <aevin@me.com>