### PR TITLE
Switch open-zfs.org links to openzfs.org, and use HTTPS URLs

### DIFF
--- a/docs/Developer Resources/Git and GitHub for beginners.rst
+++ b/docs/Developer Resources/Git and GitHub for beginners.rst
@@ -58,7 +58,7 @@ SunOS <https://www.cis.upenn.edu/~lee/06cse480/data/cstyle.ms.pdf>`__,
 `ZFS on Linux Developer
 Resources <https://github.com/zfsonlinux/zfs/wiki/Developer-Resources>`__,
 `OpenZFS Developer
-Resources <http://open-zfs.org/wiki/Developer_resources>`__
+Resources <https://openzfs.org/wiki/Developer_resources>`__
 
 Testing your patches before pushing
 -----------------------------------

--- a/docs/Developer Resources/index.rst
+++ b/docs/Developer Resources/index.rst
@@ -14,5 +14,5 @@ Developer Resources
    OpenZFS Tracking <http://build.zfsonlinux.org/openzfs-tracking.html>
    OpenZFS Patches
    OpenZFS Exceptions
-   OpenZFS Documentation <http://open-zfs.org/wiki/Developer_resources>
+   OpenZFS Documentation <https://openzfs.org/wiki/Developer_resources>
    Git and GitHub for beginners

--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -358,7 +358,7 @@ Step 2: Disk Formatting
      they are required for a Samba Active Directory domain controller.
      <https://wiki.samba.org/index.php/Setting_up_a_Share_Using_Windows_ACLs>`__
      Note that ``xattr=sa`` is `Linux-specific
-     <http://open-zfs.org/wiki/Platform_code_differences>`__. If you move your
+     <https://openzfs.org/wiki/Platform_code_differences>`__. If you move your
      ``xattr=sa`` pool to another OpenZFS implementation besides ZFS-on-Linux,
      extended attributes will not be readable (though your data will be). If
      portability of extended attributes is important to you, omit the

--- a/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
@@ -295,7 +295,7 @@ Choose one of the following options:
   they are required for a Samba Active Directory domain
   controller. <https://wiki.samba.org/index.php/Setting_up_a_Share_Using_Windows_ACLs>`__
   Note that ```xattr=sa`` is
-  Linux-specific. <http://open-zfs.org/wiki/Platform_code_differences>`__
+  Linux-specific. <https://openzfs.org/wiki/Platform_code_differences>`__
   If you move your ``xattr=sa`` pool to another OpenZFS implementation
   besides ZFS-on-Linux, extended attributes will not be readable
   (though your data will be). If portability of extended attributes is

--- a/docs/Getting Started/Ubuntu/Ubuntu 18.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 18.04 Root on ZFS.rst
@@ -285,7 +285,7 @@ Choose one of the following options:
   they are required for a Samba Active Directory domain
   controller. <https://wiki.samba.org/index.php/Setting_up_a_Share_Using_Windows_ACLs>`__
   Note that ``xattr=sa`` is
-  `Linux-specific <http://open-zfs.org/wiki/Platform_code_differences>`__.
+  `Linux-specific <https://openzfs.org/wiki/Platform_code_differences>`__.
   If you move your ``xattr=sa`` pool to another OpenZFS implementation
   besides ZFS-on-Linux, extended attributes will not be readable
   (though your data will be). If portability of extended attributes is

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
@@ -535,7 +535,7 @@ Step 2: Disk Formatting
      they are required for a Samba Active Directory domain controller.
      <https://wiki.samba.org/index.php/Setting_up_a_Share_Using_Windows_ACLs>`__
      Note that ``xattr=sa`` is `Linux-specific
-     <http://open-zfs.org/wiki/Platform_code_differences>`__. If you move your
+     <https://openzfs.org/wiki/Platform_code_differences>`__. If you move your
      ``xattr=sa`` pool to another OpenZFS implementation besides ZFS-on-Linux,
      extended attributes will not be readable (though your data will be). If
      portability of extended attributes is important to you, omit the

--- a/docs/Project and Community/Admin Documentation.rst
+++ b/docs/Project and Community/Admin Documentation.rst
@@ -4,6 +4,6 @@ Admin Documentation
 -  `Aaron Toponce's ZFS on Linux User
    Guide <https://pthree.org/2012/04/17/install-zfs-on-debian-gnulinux/>`__
 -  `OpenZFS System
-   Administration <http://open-zfs.org/wiki/System_Administration>`__
+   Administration <https://openzfs.org/wiki/System_Administration>`__
 -  `Oracle Solaris ZFS Administration
    Guide <http://docs.oracle.com/cd/E19253-01/819-5461/>`__

--- a/docs/Project and Community/FAQ.rst
+++ b/docs/Project and Community/FAQ.rst
@@ -8,7 +8,7 @@ What is ZFS on Linux
 --------------------
 
 The ZFS on Linux project is an implementation of
-`OpenZFS <http://open-zfs.org/wiki/Main_Page>`__ designed to work in a
+`OpenZFS <https://openzfs.org/wiki/Main_Page>`__ designed to work in a
 Linux environment. OpenZFS is an outstanding storage platform that
 encompasses the functionality of traditional filesystems, volume
 managers, and more, with consistent reliability, functionality and
@@ -700,4 +700,4 @@ Does ZFS on Linux have a Code of Conduct?
 -----------------------------------------
 
 Yes, the ZFS on Linux community has a code of conduct. See the `Code of
-Conduct <http://open-zfs.org/wiki/Code_of_Conduct>`__ for details.
+Conduct <https://openzfs.org/wiki/Code_of_Conduct>`__ for details.

--- a/docs/Project and Community/Mailing Lists.rst
+++ b/docs/Project and Community/Mailing Lists.rst
@@ -26,7 +26,7 @@ Mailing Lists
 +----------------------+----------------------+----------------------+
 | `devel\              | A                    | `archive <https://o  |
 | oper@open-zfs.org <h | platform-independent | penzfs.topicbox.com/ |
-| ttp://open-zfs.org/w | mailing list for ZFS | groups/developer>`__ |
+| ttps://openzfs.org/w | mailing list for ZFS | groups/developer>`__ |
 | iki/Mailing_list>`__ | developers to review |                      |
 |                      | ZFS code and         |                      |
 |                      | architecture changes |                      |


### PR DESCRIPTION
The open-zfs.org host, Dreamhost, returns a page for https://open-zfs.org
(note, httpS://) which causes HTTPS Everywhere with the 'Encrypt All
Eligible Sites' option enabled to redirect http://open-zfs.org to
https://open-zfs.org, and therefore fail to redirect to openzfs.org.
Ideally a redirect would be implemented at Dreamhost for
httpS://open-zfs.org too, but presumably the links in the docs should
really be updated anyway.