### PR TITLE
Encrypted swap patch not necessary for tmpfs

### DIFF
--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
@@ -890,6 +890,9 @@ Step 4: System Configuration
 
 #. Patch a dependency loop:
 
+
+   If you chose to put ``/tmp`` on a tmtps you can skip this step.
+
    For ZFS native encryption or LUKS::
 
      sudo apt install --yes curl patch

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
@@ -890,8 +890,7 @@ Step 4: System Configuration
 
 #. Patch a dependency loop:
 
-
-   If you chose to put ``/tmp`` on a tmtps you can skip this step.
+   If you chose to put ``/tmp`` on a tmpfs you can skip this step.
 
    For ZFS native encryption or LUKS::
 


### PR DESCRIPTION
Just a small note clarifying the necessity of the patch. I didn't test this.