### PR TITLE
edonr checksum is not secure enough for dedup

### DIFF
--- a/docs/Basic Concepts/Checksums.rst
+++ b/docs/Basic Concepts/Checksums.rst
@@ -84,13 +84,21 @@ The checksum algorithm for a dataset can be changed by setting the
 |           |              |                        | on the boot             |
 |           |              |                        | pools                   |
 +-----------+--------------+------------------------+-------------------------+
-| edonr     | no           | requires pool          | salted                  |
+| edonr     | see notes    | requires pool          | salted                  |
 |           |              | feature                | ``edonr``               |
 |           |              | ``org.illumos:edonr``  | currently not           |
 |           |              |                        | supported for           |
 |           |              |                        | any filesystem          |
 |           |              |                        | on the boot             |
 |           |              |                        | pools                   |
+|           |              |                        |                         |
+|           |              |                        | In an abundance of      |
+|           |              |                        | caution, Edon-R requires|
+|           |              |                        | verification when used  |
+|           |              |                        | with dedup, so it will  |
+|           |              |                        | automatically use       |
+|           |              |                        | ``verify``.             |
+|           |              |                        |                         |
 +-----------+--------------+------------------------+-------------------------+
 
 Checksum Accelerators

--- a/docs/Basic Concepts/Checksums.rst
+++ b/docs/Basic Concepts/Checksums.rst
@@ -84,7 +84,7 @@ The checksum algorithm for a dataset can be changed by setting the
 |           |              |                        | on the boot             |
 |           |              |                        | pools                   |
 +-----------+--------------+------------------------+-------------------------+
-| edonr     | yes          | requires pool          | salted                  |
+| edonr     | no           | requires pool          | salted                  |
 |           |              | feature                | ``edonr``               |
 |           |              | ``org.illumos:edonr``  | currently not           |
 |           |              |                        | supported for           |


### PR DESCRIPTION
Mark it as not appropriate.

Fixes https://github.com/openzfs/zfs/issues/10594