### PR TITLE
Changed typo in zpool create mirror

### DIFF
--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -383,9 +383,9 @@ Step 2: Disk Formatting
 
        zpool create \
            ... \
-           bpool mirror \
-           /dev/disk/by-id/scsi-SATA_disk1-part3 \
-           /dev/disk/by-id/scsi-SATA_disk2-part3
+           rpool mirror \
+           /dev/disk/by-id/scsi-SATA_disk1-part4 \
+           /dev/disk/by-id/scsi-SATA_disk2-part4
 
    - For raidz topologies, replace ``mirror`` in the above command with
      ``raidz``, ``raidz2``, or  ``raidz3`` and list the partitions from


### PR DESCRIPTION
There was a typo in the section where you create a mirror zpool. Someone accidently copied it  from the boot pool & forgot to change it. A friend and i were working on a mirror ZFS system for a school project & we got a error that the bpool already existed, then he pointed out that there was a typo. We decided it would be a good thing to tell you guys this ;) 

Old:
       zpool create \
           ... \
           bpool mirror \
           /dev/disk/by-id/scsi-SATA_disk1-part3 \
           /dev/disk/by-id/scsi-SATA_disk2-part3

Should be:
       zpool create \
           ... \
           rpool mirror \
           /dev/disk/by-id/scsi-SATA_disk1-part4 \
           /dev/disk/by-id/scsi-SATA_disk2-part4