### PR TITLE
Move `Performance tuning` and `Hardware` pages from openzfs wiki

### DIFF
--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -37,8 +37,7 @@ deduplication is a permanent change that cannot be easily reverted.
 Support
 ~~~~~~~
 
-If you need help, reach out to the community using the :doc:`zfs-discuss
-mailing list <../../Project and Community/Mailing Lists>` or IRC at
+If you need help, reach out to the community using the :ref:`mailing_lists` or IRC at
 `#zfsonlinux <irc://irc.freenode.net/#zfsonlinux>`__ on `freenode
 <https://freenode.net/>`__. If you have a bug report or feature request
 related to this HOWTO, please `file a new issue and mention @rlaager

--- a/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
@@ -41,8 +41,7 @@ deduplication is a permanent change that cannot be easily reverted.
 Support
 ~~~~~~~
 
-If you need help, reach out to the community using the :doc:`zfs-discuss
-mailing list <../../Project and Community/Mailing Lists>` or IRC at
+If you need help, reach out to the community using the :ref:`mailing_lists` or IRC at
 `#zfsonlinux <irc://irc.freenode.net/#zfsonlinux>`__ on `freenode
 <https://freenode.net/>`__. If you have a bug report or feature request
 related to this HOWTO, please `file a new issue and mention @rlaager

--- a/docs/Getting Started/Ubuntu/Ubuntu 16.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 16.04 Root on ZFS.rst
@@ -41,8 +41,7 @@ deduplication is a permanent change that cannot be easily reverted.
 Support
 ~~~~~~~
 
-If you need help, reach out to the community using the :doc:`zfs-discuss
-mailing list <../../Project and Community/Mailing Lists>` or IRC at
+If you need help, reach out to the community using the :ref:`mailing_lists` or IRC at
 `#zfsonlinux <irc://irc.freenode.net/#zfsonlinux>`__ on `freenode
 <https://freenode.net/>`__. If you have a bug report or feature request
 related to this HOWTO, please `file a new issue and mention @rlaager

--- a/docs/Getting Started/Ubuntu/Ubuntu 18.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 18.04 Root on ZFS.rst
@@ -42,8 +42,7 @@ deduplication is a permanent change that cannot be easily reverted.
 Support
 ~~~~~~~
 
-If you need help, reach out to the community using the :doc:`zfs-discuss
-mailing list <../../Project and Community/Mailing Lists>` or IRC at
+If you need help, reach out to the community using the :ref:`mailing_lists` or IRC at
 `#zfsonlinux <irc://irc.freenode.net/#zfsonlinux>`__ on `freenode
 <https://freenode.net/>`__. If you have a bug report or feature request
 related to this HOWTO, please `file a new issue and mention @rlaager

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
@@ -39,8 +39,7 @@ bad) using the issue link below.
 Support
 ~~~~~~~
 
-If you need help, reach out to the community using the :doc:`zfs-discuss
-mailing list <../../Project and Community/Mailing Lists>` or IRC at
+If you need help, reach out to the community using the :ref:`mailing_lists` or IRC at
 `#zfsonlinux <irc://irc.freenode.net/#zfsonlinux>`__ on `freenode
 <https://freenode.net/>`__. If you have a bug report or feature request
 related to this HOWTO, please `file a new issue and mention @rlaager

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
@@ -187,8 +187,7 @@ deduplication is a permanent change that cannot be easily reverted.
 Support
 ~~~~~~~
 
-If you need help, reach out to the community using the :doc:`zfs-discuss
-mailing list <../../Project and Community/Mailing Lists>` or IRC at
+If you need help, reach out to the community using the :ref:`mailing_lists` or IRC at
 `#zfsonlinux <irc://irc.freenode.net/#zfsonlinux>`__ on `freenode
 <https://freenode.net/>`__. If you have a bug report or feature request
 related to this HOWTO, please `file a new issue and mention @rlaager

--- a/docs/Performance and Tuning/Hardware.rst
+++ b/docs/Performance and Tuning/Hardware.rst
@@ -1,6 +1,9 @@
 Hardware
 ********
 
+.. contents:: Table of Contents
+  :local:
+
 Introduction
 ============
 

--- a/docs/Performance and Tuning/Hardware.rst
+++ b/docs/Performance and Tuning/Hardware.rst
@@ -668,9 +668,7 @@ non-existent.
 ATA TRIM / SCSI UNMAP
 ---------------------
 
-At this time, only the FreeBSD port has support for sending block
-discard commands to vdevs to generate appropriate ATA TRIM and/or SCSI
-UNMAP commands. It should be noted that this is a separate case from
+It should be noted that this is a separate case from
 discard on zvols or hole punching on filesystems. Those work regardless
 of whether ATA TRIM / SCSI UNMAP is sent to the actual block devices.
 

--- a/docs/Performance and Tuning/Hardware.rst
+++ b/docs/Performance and Tuning/Hardware.rst
@@ -1,0 +1,797 @@
+Introduction
+============
+
+Storage before ZFS involved rather expensive hardware that was unable to
+protect against silent corruption and did not scale very well. The
+introduction of ZFS has enabled people to use far less expensive
+hardware than previously used in the industry with superior scaling.
+This page attempts to provide some basic guidance to people buying
+hardware for use in ZFS-based servers and workstations.
+
+Hardware that adheres to this guidance will enable ZFS to reach its full
+potential for performance and reliability. Hardware that does not adhere
+to it will serve as a handicap. Unless otherwise stated, such handicaps
+apply to all storage stacks and are by no means specific to ZFS. Systems
+built using competing storage stacks will also benefit from these
+suggestions.
+
+.. _bios_cpu_microcode_updates:
+
+BIOS / CPU microcode updates
+============================
+
+Running the latest BIOS and CPU microcode is highly recommended.
+
+Background
+----------
+
+Computer microprocessors are very complex designs that often have bugs,
+which are called errata. Modern microprocessors are designed to utilize
+microcode. This puts part of the hardware design into quasi-software
+that can be patched without replacing the entire chip. Errata are often
+resolved through CPU microcode updates. These are often bundled in BIOS
+updates. In some cases, the BIOS interactions with the CPU through
+machine registers can be modified to fix things with the same microcode.
+If a newer microcode is not bundled as part of a BIOS update, it can
+often be loaded by the operating system bootloader or the operating
+system itself.
+
+.. _ecc_memory:
+
+ECC Memory
+==========
+
+Bit flips can have fairly dramatic consequences for all computer
+filesystems and ZFS is no exception. No technique used in ZFS (or any
+other filesystem) is capable of protecting against bit flips.
+Consequently, ECC Memory is highly recommended.
+
+.. _background_1:
+
+Background
+----------
+
+Ordinary background radiation will randomly flip bits in computer
+memory, which causes undefined behavior. These are known as "bit flips".
+Each bit flip can have any of three possible consequences depending on
+which bit is flipped:
+
+-  Bit flips can have no effect.
+
+   -  Bit flips that have no effect occur in unused memory.
+
+-  Bit flips can cause runtime failures.
+
+   -  This is the case when a bit flip occurs in something read from
+      disk.
+   -  Failures are typically observed when program code is altered.
+   -  If the bit flip is in a routine within the system's kernel or
+      /sbin/init, the system will likely crash. Otherwise, reloading the
+      affected data can clear it. This is typically achieved by a
+      reboot.
+
+-  It can cause data corruption.
+
+   -  This is the case when the bit is in use by data being written to
+      disk.
+   -  If the bit flip occurs before ZFS' checksum calculation, ZFS will
+      not realize that the data is corrupt.
+   -  If the bit flip occurs after ZFS' checksum calculation, but before
+      write-out, ZFS will detect it, but it might not be able to correct
+      it.
+
+-  It can cause metadata corruption.
+
+   -  This is the case when a bit flips in an on-disk structure being
+      written to disk.
+   -  If the bit flip occurs before ZFS' checksum calculation, ZFS will
+      not realize that the metadata is corrupt.
+   -  If the bit flip occurs after ZFS' checksum calculation, but before
+      write-out, ZFS will detect it, but it might not be able to correct
+      it.
+   -  Recovery from such an event will depend on what was corrupted. In
+      the worst, case, a pool could be rendered unimportable.
+
+      -  All filesystems have poor reliability in their absolute worst
+         case bit-flip failure scenarios. Such scenarios should be
+         considered extraordinarily rare.
+
+.. _drive_interfaces:
+
+Drive Interfaces
+================
+
+.. _sas_versus_sata:
+
+SAS versus SATA
+---------------
+
+ZFS depends on the block device layer for storage. Consequently, ZFS is
+affected by the same things that affect other filesystems, such as
+driver support and non-working hardware. Consequently, there are a few
+things to note:
+
+-  Never place SATA disks into a SAS expander without a SAS interposer.
+
+   -  If you do this and it does work, it is the exception, rather than
+      the rule.
+
+-  Do not expect SAS controllers to be compatible with SATA port
+   multipliers.
+
+   -  This configuration is typically not tested.
+   -  The disks could be unrecognized.
+
+-  Support for SATA port multipliers is inconsistent across Open ZFS
+   platforms
+
+   -  Linux drivers generally support them.
+   -  Illumos drivers generally do not support them.
+   -  FreeBSD drivers are somewhere between Linux and Illumos in terms
+      of support.
+
+.. _usb_hard_drives_andor_adapters:
+
+USB Hard Drives and/or Adapters
+-------------------------------
+
+These have problems involving sector size reporting, SMART passthrough,
+the ability to set ERC and other areas. ZFS will perform as well on such
+devices as they are capable of allowing, but try to avoid them. They
+should not be expected to have the same up-time as SAS and SATA drives
+and should be considered unreliable.
+
+Controllers
+===========
+
+The ideal storage controller for ZFS has the following attributes:
+
+-  Driver support on major Open ZFS platforms
+
+   -  Stability is important.
+
+-  High per-port bandwidth
+
+   -  PCI Express interface bandwidth divided by the number of ports
+
+-  Low cost
+
+   -  Support for RAID, Battery Backup Units and hardware write caches
+      is unnecessary.
+
+Marc Bevand's blog post `From 32 to 2 ports: Ideal SATA/SAS Controllers
+for ZFS & Linux MD RAID <http://blog.zorinaq.com/?e=10>`__ contains an
+excellent list of storage controllers that meet these criteria. He
+regularly updates it as newer controllers become available.
+
+.. _hardware_raid_controllers:
+
+Hardware RAID controllers
+-------------------------
+
+Hardware RAID controllers should not be used with ZFS. While ZFS will
+likely be more reliable than other filesystems on Hardware RAID, it will
+not be as reliable as it would be on its own.
+
+-  Hardware RAID will limit opportunities for ZFS to perform self
+   healing on checksum failures. When ZFS does RAID-Z or mirroring, a
+   checksum failure on one disk can be corrected by treating the disk
+   containing the sector as bad for the purpose of reconstructing the
+   original information. This cannot be done when a RAID controller
+   handles the redundancy unless a duplicate copy is stored by ZFS in
+   the case that the corruption involving as metadata, the copies flag
+   is set or the RAID array is part of a mirror/raid-z vdev within ZFS.
+
+-  Sector size information is not necessarily passed correctly by
+   hardware RAID on RAID 1 and cannot be passed correctly on RAID 5/6.
+   Hardware RAID 1 is more likely to experience read-modify-write
+   overhead from partial sector writes and Hardware RAID 5/6 will almost
+   certainty suffer from partial stripe writes (i.e. the RAID write
+   hole). Using ZFS with the disks directly will allow it to obtain the
+   sector size information reported by the disks to avoid
+   read-modify-write on sectors while ZFS avoids partial stripe writes
+   on RAID-Z by desing from using copy-on-write.
+
+   -  There can be sector alignment problems on ZFS when a drive
+      misreports its sector size. Such drives are typically NAND-flash
+      based solid state drives and older SATA drives from the advanced
+      format (4K sector size) transition before Windows XP EoL occurred.
+      This can be `manually
+      corrected <Performance_tuning#Alignment_Shift_.28ashift.29>`__ at
+      vdev creation.
+   -  It is possible for the RAID header to cause misalignment of sector
+      writes on RAID 1 by starting the array within a sector on an
+      actual drive, such that manual correction of sector alignment at
+      vdev creation does not solve the problem.
+
+-  Controller failures can require that the controller be replaced with
+   the same model, or in less extreme cases, a model from the same
+   manufacturer. Using ZFS by itself allows any controller to be used.
+
+-  If a hardware RAID controller's write cache is used, an additional
+   failure point is introduced that can only be partially mitigated by
+   additional complexity from adding flash to save data in power loss
+   events. The data can still be lost if the battery fails when it is
+   required to survive a power loss event or there is no flash and power
+   is not restored in a timely manner. The loss of the data in the write
+   cache can severely damage anything stored on a RAID array when many
+   outstanding writes are cached. In addition, all writes are stored in
+   the cache rather than just synchronous writes that require a write
+   cache, which is inefficient, and the write cache is relatively small.
+   ZFS allows synchronous writes to be written directly to flash, which
+   should provide similar acceleration to hardware RAID and the ability
+   to accelerate many more in-flight operations.
+
+-  Behavior during RAID reconstruction when silent corruption damages
+   data is undefined. There are reports of RAID 5 and 6 arrays being
+   lost during reconstruction when the controller encounters silent
+   corruption. ZFS' checksums allow it to avoid this situation by
+   determining if not enough information exists to reconstruct data. In
+   which case, the file is listed as damaged in zpool status and the
+   system administrator has the opportunity to restore it from a backup.
+
+-  IO response times will be reduced whenever the OS blocks on IO
+   operations because the system CPU blocks on a much weaker embedded
+   CPU used in the RAID controller. This lowers IOPS relative to what
+   ZFS could have achieved.
+
+-  The controller's firmware is an additional layer of complexity that
+   cannot be inspected by arbitrary third parties. The ZFS source code
+   is open source and can be inspected by anyone.
+
+-  If multiple RAID arrays are formed by the same controller and one
+   fails, the identifiers provided by the arrays exposed to the OS might
+   become inconsistent. Giving the drives directly to the OS allows this
+   to be avoided via naming that maps to a unique port or unique drive
+   identifier.
+
+   -  e.g. If you have arrays A, B, C and D; array B dies, the
+      interaction between the hardware RAID controller and the OS might
+      rename arrays C and D to look like arrays B and C respectively.
+      This can fault pools verbatim imported from the cachefile.
+   -  Not all RAID controllers behave this way. However, this issue has
+      been observed on both Linux and FreeBSD when system administrators
+      used single drive RAID 0 arrays. It has also been observed with
+      controllers from different vendors.
+
+One might be inclined to try using single-drive RAID 0 arrays to try to
+use a RAID controller like a HBA, but this is not recommended for many
+of the reasons listed for other hardware RAID types. It is best to use a
+HBA instead of a RAID controller, for both performance and reliability.
+
+.. _hard_drives:
+
+Hard drives
+===========
+
+.. _sector_size:
+
+Sector Size
+-----------
+
+Historically, all hard drives had 512-byte sectors, with the exception
+of some SCSI drives that could be modified to support slightly larger
+sectors. In 2009, the industry migrated from 512-byte sectors to
+4096-byte "Advanced Format" sectors. Since Windows XP is not compatible
+with 4096-byte sectors or drives larger than 2TB, some of the first
+advanced format drives implemented hacks to maintain Windows XP
+compatibility.
+
+-  The first advanced format drives on the market misreported their
+   sector size as 512-bytes for Windows XP compatibility. As of 2013, it
+   is believed that such hard drives are no longer in production.
+   Advanced format hard drives made during or after this time should
+   report their true physical sector size.
+-  Drives storing 2TB and smaller might have a jumper that can be set to
+   map all sectors off by 1. This to provide proper alignment for
+   Windows XP, which started its first partition at sector 63. This
+   jumper setting should be off when using such drives with ZFS.
+
+As of 2014, there are still 512-byte and 4096-byte drives on the market,
+but they are known to properly identify themselves unless behind a USB
+to SATA controller. Replacing a 512-byte sector drive with a 4096-byte
+sector drives in a vdev created with 512-byte sector drives will
+adversely affect performance. Replacing a 4096-byte sector drive with a
+512-byte sector drive will have no negative effect on performance.
+
+.. _error_recovery_control:
+
+Error recovery control
+----------------------
+
+ZFS is said to be able to use cheap drives. This was true when it was
+introduced and hard drives supported Error recovery control. Since ZFS'
+introduction, error recovery control has been removed from low-end
+drives from certain manufacturers, most notably Western Digital.
+Consistent performance requires hard drives that support error recovery
+control.
+
+.. _background_2:
+
+Background
+~~~~~~~~~~
+
+Hard drives store data using small polarized regions a magnetic surface.
+Reading from and/or writing to this surface poses a few reliability
+problems. One is that imperfections in the surface can corrupt bits.
+Another is that vibrations can cause drive heads to miss their targets.
+Consequently, hard drive sectors are composed of three regions:
+
+-  A sector number
+-  The actual data
+-  ECC
+
+The sector number and ECC enables hard drives to detect and respond to
+such events. When either event occurs during a read, hard drives will
+retry the read many times until they either succeed or conclude that the
+data cannot be read. The latter case can take a substantial amount of
+time and consequently, IO to the drive will stall.
+
+Enterprise hard drives and some consumer hard drives implement a feature
+called Time-Limited Error Recovery (TLER) by Western Digital, Error
+Recovery Control (ERC) by Seagate and Command Completion Time Limit by
+Hitachi and Samsung, which permits the time drives are willing to spend
+on such events to be limited by the system administrator.
+
+Drives that lack such functionality can be expected to have arbitrarily
+high limits. Several minutes is not impossible. Drives with this
+functionality typically default to 7 seconds. ZFS does not currently
+adjust this setting on drives. However, it is advisable to write a
+script to set the error recovery time to a low value, such as 0.1
+seconds until ZFS is modified to control it. This must be done on every
+boot.
+
+.. _rpm_speeds:
+
+RPM Speeds
+----------
+
+High RPM drives have lower seek times, which is historically regarded as
+being desirable. They increase cost and sacrifice storage density in
+order to achieve what is typically no more than a factor of 6
+improvement over their lower RPM counterparts.
+
+To provide some numbers, a 15k RPM drive from a major manufacturer is
+rated for 3.4 millisecond average read and 3.9 millisecond average
+write. Presumably, this number assumes that the target sector is at most
+half the number of drive tracks away from the head and half the disk
+away. Being even further away is worst-case 2 times slower. Manufacturer
+numbers for 7200 RPM drives are not available, but they average 13 to 16
+milliseconds in empirical measurements. 5400 RPM drives can be expected
+to be slower.
+
+ARC and ZIL are able to mitigate much of the benefit of lower seek
+times. Far larger increases in IOPS performance can be obtained by
+adding additional RAM for ARC, L2ARC devices and SLOG devices. Even
+higher increases in performance can be obtained by replacing hard drives
+with solid state storage entirely. Such things are typically more cost
+effective than high RPM drives when considering IOPS.
+
+.. _command_queuing:
+
+Command Queuing
+---------------
+
+Drives with command queues are able to reorder IO operations to increase
+IOPS. This is called Native Command Queuing on SATA and Tagged Command
+Queuing on PATA/SCSI/SAS. ZFS stores objects in metaslabs and it can use
+several metastabs at any given time. Consequently, ZFS is not only
+designed to take advantage of command queuing, but good ZFS performance
+requires command queuing. Almost all drives manufactured within the past
+10 years can be expected to support command queuing. The exceptions are:
+
+-  Consumer PATA/IDE drives
+-  First generation SATA drives, which used IDE to SATA translation
+   chips, from 2003 to 2004.
+-  SATA drives operating under IDE emulation that was configured in the
+   system BIOS.
+
+Each Open ZFS system has different methods for checking whether command
+queuing is supported. On Linux, \`hdparm -I /path/to/device \| grep
+Queue\` is used. On FreeBSD, \`camcontrol identify $DEVICE\` is used.
+
+.. _nand_flash_ssds:
+
+NAND Flash SSDs
+===============
+
+As of 2014, Solid state storage is dominated by NAND-flash and most
+articles on solid state storage focus on it exclusively. As of 2014, the
+most popular form of flash storage used with ZFS involve drives with
+SATA interfaces. Enterprise models with SAS interfaces are beginning to
+become available.
+
+As of 2017, Solid state storage using NAND-flash with PCI-E interfaces
+are widely available on the market. They are predominantly enterprise
+drives that utilize a NVMe interface that has lower overhead than the
+ATA used in SATA or SCSI used in SAS. There is also an interface known
+as M.2 that is primarily used by consumer SSDs, although not necessarily
+limited to them. It can provide electrical connectivity for multiple
+buses, such as SATA, PCI-E and USB. M.2 SSDs appear to use either SATA
+or NVME.
+
+.. _nvme_low_level_formatting:
+
+NVMe low level formatting
+-------------------------
+
+Many NVMe SSDs support both 512-byte sectors and 4096-byte sectors. They
+often ship with 512-byte sectors, which are less performant than
+4096-byte sectors. Some also support metadata for T10/DIF CRC to try to
+improve reliability, although this is unnecessary with ZFS.
+
+NVMe drives should be
+`formatted <https://filers.blogspot.com/2018/12/how-to-format-nvme-drive.html>`__
+to use 4096-byte sectors without metadata prior to being given to ZFS
+for best performance unless they indicate that 512-byte sectors are as
+performant as 4096-byte sectors, although this is unlikely. Lower
+numbers in the Rel_Perf of Supported LBA Sizes from \`smartctl -a
+/dev/$device_namespace\` (for example \`smartctl -a /dev/nvme1n1`)
+indicate higher performance low level formats, with 0 being the best.
+The current formatting will be marked by a plus sign under the format
+Fmt.
+
+You may format a drive using \`nvme format /dev/nvme1n1 -l $ID`. The $ID
+corresponds to the Id field value from the Supported LBA Sizes SMART
+information.
+
+.. _power_failure_protection:
+
+Power Failure Protection
+------------------------
+
+.. _background_3:
+
+Background
+~~~~~~~~~~
+
+On-flash data structures are highly complex and traditionally have been
+highly vulnerable to corruption. In the past, such corruption would
+result in the loss of \*all\* drive data and an event such as a PSU
+failure could result in multiple drives simultaneously failing. Since
+the drive firmware is not available for review, the traditional
+conclusion was that all drives that lack hardware features to avoid
+power failure events cannot be trusted, which was found to be the case
+multiple times in the
+past\ `1 <http://lkcl.net/reports/ssd_analysis.html>`__\ `2 <https://www.usenix.org/system/files/conference/fast13/fast13-final80.pdf>`__\ `3 <http://blog.nordeus.com/dev-ops/power-failure-testing-with-ssds.htm>`__.
+Discussion of power failures bricking NAND flash SSDs appears to have
+vanished from literature following the year 2015. SSD manufacturers now
+claim that firmware power loss protection is robust enough to provide
+equivalent protection to hardware power loss protection. Kingston is one
+example\ `4 <https://www.kingston.com/us/solutions/servers-data-centers/ssd-power-loss-protection>`__.
+Firmware power loss protection is used to guarantee the protection of
+flushed data and the drives’ own metadata, which is all that filesystems
+such as ZFS need.
+
+However, those that either need or want strong guarantees that firmware
+bugs are unlikely to be able to brick drives following power loss events
+should continue to use drives that provide hardware power loss
+protection. The basic concept behind how hardware power failure
+protection works has been `documented by
+Intel <https://www.intel.com/content/dam/www/public/us/en/documents/technology-briefs/ssd-power-loss-imminent-technology-brief.pdf>`__
+for those who wish to read about the details. As of 2020, use of
+hardware power loss protection is now a feature solely of enterprise
+SSDs that attempt to protect unflushed data in addition to drive
+metadata and flushed data. This additional protection beyond protecting
+flushed data and the drive metadata provides no additional benefit to
+ZFS, but it does not hurt it.
+
+It should also be noted that drives in data centers and laptops are
+unlikely to experience power loss events, reducing the usefulness of
+hardware power loss protection. This is especially the case in
+datacenters where redundant power, UPS power and the use of IPMI to do
+forced reboots should prevent most drives from experiencing power loss
+events.
+
+Lists of drives that provide hardware power loss protection are
+maintained below for those who need/want it. Since ZFS, like other
+filesystems, only requires power failure protection for flushed data and
+drive metadata, older drives that only protect these things are included
+on the lists.
+
+.. _nvme_drives_with_power_failure_protection:
+
+NVMe drives with power failure protection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A non-exhaustive list of NVMe drives with power failure protection is as
+follows:
+
+-  Intel 750
+-  Intel DC P3500/P3600/P3608/P3700
+-  Samsung PM963 (M.2 form factor)
+-  Samsung PM1725/PM1725a
+-  Samsung XS1715
+-  Toshiba ZD6300
+-  Seagate Nytro 5000 M.2 (XP1920LE30002 tested; **read notes below
+   before buying**)
+
+   -  Inexpensive 22110 M.2 enterprise drive using consumer MLC that is
+      optimized for read mostly workloads. It is not a good choice for a
+      SLOG device, which is a write mostly workload.
+   -  The
+      `manual <https://www.seagate.com/www-content/support-content/enterprise-storage/solid-state-drives/nytro-5000/_shared/docs/nytro-5000-mp2-pm-100810195d.pdf>`__
+      for this drive specifies airflow requirements. If the drive does
+      not receive sufficient airflow from case fans, it will overheat at
+      idle. It's thermal throttling will severely degrade performance
+      such that write throughput performance will be limited to 1/10 of
+      the specification and read latencies will reach several hundred
+      milliseconds. Under continuous load, the device will continue to
+      become hotter until it suffers a "degraded reliability" event
+      where all data on at least one NVMe namespace is lost. The NVMe
+      namespace is then unusable until a secure erase is done. Even with
+      sufficient airflow under normal circumstances, data loss is
+      possible under load following the failure of fans in an enterprise
+      environment. Anyone deploying this into production in an
+      enterprise environment should be mindful of this failure mode.
+   -  Those who wish to use this drive in a low airflow situation can
+      workaround this failure mode by placing a passive heatsink such as
+      `this <https://smile.amazon.com/gp/product/B07BDKN3XV>`__ on the
+      NAND flash controller. It is the chip under the sticker closest to
+      the capacitors. This was tested by placing the heatsink over the
+      sticker (as removing it was considered undesirable). The heatsink
+      will prevent the drive from overheating to the point of data loss,
+      but it will not fully alleviate the overheating situation under
+      load without active airflow. A scrub will cause it to overheat
+      after a few hundred gigabytes are read. However, the thermal
+      throttling will quickly cool the drive from 76 degrees Celsius to
+      74 degrees Celsius, restoring performance.
+
+      -  It might be possible to use the heatsink in an enterprise
+         environment to provide protection against data loss following
+         fan failures. However, this was not evaluated. Furthermore,
+         operating temperatures for consumer NAND flash should be at or
+         above 40 degrees Celsius for long term data integrity.
+         Therefore, the use of a heatsink to provide protection against
+         data loss following fan failures in an enterprise environment
+         should be evaluated before deploying drives into production to
+         ensure that the drive is not overcooled.
+
+.. _sas_drives_with_power_failure_protection:
+
+SAS drives with power failure protection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A non-exhaustive list of SAS drives with power failure protection is as
+follows:
+
+-  Samsung PM1633/PM1633a
+-  Samsung SM1625
+-  Samsung PM853T
+-  Toshiba PX05SHB***/PX04SHB***/PX04SHQ**\*
+-  Toshiba PX05SLB***/PX04SLB***/PX04SLQ**\*
+-  Toshiba PX05SMB***/PX04SMB***/PX04SMQ**\*
+-  Toshiba PX05SRB***/PX04SRB***/PX04SRQ**\*
+-  Toshiba PX05SVB***/PX04SVB***/PX04SVQ**\*
+
+.. _sata_drives_with_power_failure_protection:
+
+SATA drives with power failure protection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A non-exhaustive list of SATA drives with power failure protection is as
+follows:
+
+-  Crucial MX100/MX200/MX300
+-  Crucial M500/M550/M600
+-  Intel 320
+
+   -  Early reports claimed that the 330 and 335 had power failure
+      protection too, but they do
+      not.\ `5 <http://blog.nordeus.com/dev-ops/power-failure-testing-with-ssds.htm>`__
+
+-  Intel 710
+-  Intel 730
+-  Intel DC S3500/S3510/S3610/S3700/S3710
+-  Micron 5210 Ion
+
+   -  First QLC drive on the list. High capacity with a low price per
+      gigabyte.
+
+-  Samsung PM863/PM863a
+-  Samsung SM843T (do not confuse with SM843)
+-  Samsung SM863/SM863a
+-  Samsung 845DC Evo
+-  Samsung 845DC Pro
+
+   -  High sustained write
+      IOPS\ `6 <http://www.anandtech.com/show/8319/samsung-ssd-845dc-evopro-preview-exploring-worstcase-iops/5>`__
+
+-  Toshiba HK4E/HK3E2
+-  Toshiba HK4R/HK3R2/HK3R
+
+.. _criteriaprocess_for_inclusion_into_these_lists:
+
+Criteria/process for inclusion into these lists
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These lists have been compiled on a volunteer basis by OpenZFS
+contributors (mainly Richard Yao) from trustworthy sources of
+information. The lists are intended to be vendor neutral and are not
+intended to benefit any particular manufacturer. Any perceived bias
+toward any manufacturer is caused by a lack of awareness and a lack of
+time to research additional options. Confirmation of the presence of
+adequate power loss protection by a reliable source is the only
+requirement for inclusion into this list. Adequate power loss protection
+means that the drive must protect both its own internal metadata and all
+flushed data. Protection of unflushed data is irrelevant and therefore
+not a requirement. ZFS only expects storage to protect flushed data.
+Consequently, solid state drives whose power loss protection only
+protects flushed data is sufficient for ZFS to ensure that data remains
+safe.
+
+Anyone who believes an unlisted drive to provide adequate power failure
+protection may contact the `OpenZFS mailing list <mailing_list>`__ with
+a request for inclusion and substantiation for the claim that power
+failure protection is provided. Examples of substantiation include
+pictures of drive internals showing the presence of capacitors,
+statements by well regarded independent review sites such as Anandtech
+and manufacturer specification sheets. The latter are accepted on the
+honor system until a manufacturer is found to misstate reality on the
+protection of the drives' own internal metadata structures and/or the
+protection of flushed data. Thus far, all manufacturers have been
+honest.
+
+.. _flash_pages:
+
+Flash pages
+-----------
+
+The smallest unit on a NAND chip that can be written is a flash page.
+The first NAND-flash SSDs on the market had 4096-byte pages. Further
+complicating matters is that the the page size has been doubled twice
+since then. NAND flash SSDs \*should\* report these pages as being
+sectors, but so far, all of them incorrectly report 512-byte sectors for
+Windows XP compatibility. The consequence is that we have a similar
+situation to what we had with early advanced format hard drives.
+
+As of 2014, most NAND-flash SSDs on the market have 8192-byte page
+sizes. However, models using 128-Gbit NAND from certain manufacturers
+have a 16384-byte page size. Maximum performance requires that vdevs be
+created with correct ashift values (13 for 8192-byte and 14 for
+16384-byte). However, not all Open ZFS platforms support this. The Linux
+port supports ashift=13, while others are limited to ashift=12
+(4096-byte).
+
+As of 2017, NAND-flash SSDs are tuned for 4096-byte IOs. Matching the
+flash page size is unnecessary and ashift=12 is usually the correct
+choice. Public documentation on flash page size is also nearly
+non-existent.
+
+.. _ata_trim_scsi_unmap:
+
+ATA TRIM / SCSI UNMAP
+---------------------
+
+At this time, only the FreeBSD port has support for sending block
+discard commands to vdevs to generate appropriate ATA TRIM and/or SCSI
+UNMAP commands. It should be noted that this is a separate case from
+discard on zvols or hole punching on filesystems. Those work regardless
+of whether ATA TRIM / SCSI UNMAP is sent to the actual block devices.
+
+.. _ata_trim_performance_issues:
+
+ATA TRIM Performance Issues
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ATA TRIM command in SATA 3.0 and earlier is a non-queued command.
+Issuing a TRIM command on a SATA drive conforming to SATA 3.0 or earlier
+will cause the drive to drain its IO queue and stop servicing requests
+until it finishes, which hurts performance. SATA 3.1 removed this
+limitation, but very few SATA drives on the market are conformant to
+SATA 3.1 and it is difficult to distinguish them from SATA 3.0 drives.
+At the same time, SCSI UNMAP has no such problems.
+
+.. _optane_3d_xpoint_ssds:
+
+Optane / 3D XPoint SSDs
+=======================
+
+These are SSDs with far better latencies and write endurance than NAND
+flash SSDs. They are byte addressable, such that ashift=9 is fine for
+use on them. Unlike NAND flash SSDs, they do not require any special
+power failure protection circuitry for reliability. There is also no
+need to run TRIM on them. However, they cost more per GB than NAND flash
+(as of 2020). The enterprise models make excellent SLOG devices. Here is
+a list of models that are known to perform well:
+
+-  Intel DC
+   P4800X\ `7 <https://www.servethehome.com/intel-optane-hands-on-real-world-benchmark-and-test-results/>`__
+
+   -  This gives basically the highest performance you can get as of
+      June 2020.
+
+Also, at time of writing in June 2020, only one model is listed. This is
+due to there being few such drives on the market. The client models are
+likely to be outperformed by well configured NAND flash drives, so they
+have not been listed (although they are likely cheaper than NAND flash).
+More will likely be added in the future.
+
+Note that SLOG devices rarely have more than 4GB in use at any given
+time, so the smaller sized devices are generally the best choice in
+terms of cost, with larger sizes giving no benefit. Larger sizes could
+be a good choice for other vdev types, depending on performance needs
+and cost considerations.
+
+Power
+=====
+
+Ensuring that computers are properly grounded is highly recommended.
+There have been cases in user homes where machines experienced random
+failures when plugged into power receptacles that had open grounds (i.e.
+no ground wire at all). This can cause random failures on any computer
+system, whether it uses ZFS or not.
+
+Power should also be relatively stable. Large dips in voltages from
+brownouts are preferably avoided through the use of UPS units or line
+conditioners. Systems subject to unstable power that do not outright
+shutdown can exhibit undefined behavior. PSUs with longer hold-up times
+should be able to provide partial protection against this, but hold up
+times are often undocumented and are not a substitute for a UPS or line
+conditioner.
+
+.. _pwr_ok_signal:
+
+PWR_OK signal
+-------------
+
+PSUs are supposed to deassert a PWR_OK signal to indicate that provided
+voltages are no longer within the rated specification. This should force
+an immediate shutdown. However, the system clock of a developer
+workstation was observed to significantly deviate from the expected
+value following during a series of ~1 second brown outs. This machine
+did not use a UPS at the time. However, the PWR_OK mechanism should have
+protected against this. The observation of the PWR_OK signal failing to
+force a shutdown with adverse consequences (to the system clock in this
+case) suggests that the PWR_OK mechanism is not a strict guarantee.
+
+.. _psu_hold_up_times:
+
+PSU Hold-up Times
+-----------------
+
+A PSU hold-up time is the amount of time that a PSU can continue to
+output power at maximum output within standard voltage tolerances
+following the loss of input power. This is important for supporting UPS
+units because `the transfer
+time <https://www.sunpower-uk.com/glossary/what-is-transfer-time/>`__
+taken by a standard UPS to supply power from its battery can leave
+machines without power for "5-12 ms". `Intel's ATX Power Supply design
+guide <https://paginas.fe.up.pt/~asousa/pc-info/atxps09_atx_pc_pow_supply.pdf>`__
+specifies a hold up time of 17 milliseconds at maximum continuous
+output. The hold-up time is a inverse function of how much power is
+being output by the PSU, with lower power output increasing holdup
+times.
+
+Capacitor aging in PSUs will lower the hold-up time below what it was
+when new, which could cause reliability issues as equipment ages.
+Machines using substandard PSUs with hold-up times below the
+specification therefore require higher end UPS units for protection to
+ensure that the transfer time does not exceed the hold-up time. A
+hold-up time below the transfer time during a transfer to battery power
+can cause undefined behavior should the PWR_OK signal not become
+deasserted to force the machine to poser off.
+
+If in doubt, use a double conversion UPS unit. Double conversion UPS
+units always run off the battery, such that the transfer time is 0. This
+is unless they are high efficiency models that are hybrids between
+standard UPS units and double conversion UPS units, although these are
+reported to have much lower transfer times than standard PSUs. You could
+also contact your PSU manufacturer for the hold up time specification,
+but if reliability for years is a requirement, you should use a higher
+end UPS with a low transfer time.
+
+Note that double conversion units are at most 94% efficient unless they
+support a high efficiency mode, which adds latency to the time to
+transition to battery power.
+
+.. _ups_batteries:
+
+UPS batteries
+-------------
+
+The lead acid batteries in UPS units generally need to be replaced
+regularly to ensure that they provide power during power outages. For
+home systems, this is every 3 to 5 years, although this varies with
+temperature\ `8 <https://www.apc.com/us/en/faqs/FA158934/>`__. For
+enterprise systems, contact your vendor.

--- a/docs/Performance and Tuning/Hardware.rst
+++ b/docs/Performance and Tuning/Hardware.rst
@@ -1,3 +1,6 @@
+Hardware
+********
+
 Introduction
 ============
 
@@ -196,8 +199,7 @@ not be as reliable as it would be on its own.
       misreports its sector size. Such drives are typically NAND-flash
       based solid state drives and older SATA drives from the advanced
       format (4K sector size) transition before Windows XP EoL occurred.
-      This can be `manually
-      corrected <Performance_tuning#Alignment_Shift_.28ashift.29>`__ at
+      This can be :ref:`manually corrected <alignment_shift_ashift>` at
       vdev creation.
    -  It is possible for the RAID header to cause misalignment of sector
       writes on RAID 1 by starting the array within a sector on an
@@ -387,8 +389,8 @@ requires command queuing. Almost all drives manufactured within the past
    system BIOS.
 
 Each Open ZFS system has different methods for checking whether command
-queuing is supported. On Linux, \`hdparm -I /path/to/device \| grep
-Queue\` is used. On FreeBSD, \`camcontrol identify $DEVICE\` is used.
+queuing is supported. On Linux, ``hdparm -I /path/to/device \| grep
+Queue`` is used. On FreeBSD, ``camcontrol identify $DEVICE`` is used.
 
 .. _nand_flash_ssds:
 
@@ -425,13 +427,13 @@ NVMe drives should be
 to use 4096-byte sectors without metadata prior to being given to ZFS
 for best performance unless they indicate that 512-byte sectors are as
 performant as 4096-byte sectors, although this is unlikely. Lower
-numbers in the Rel_Perf of Supported LBA Sizes from \`smartctl -a
-/dev/$device_namespace\` (for example \`smartctl -a /dev/nvme1n1`)
+numbers in the Rel_Perf of Supported LBA Sizes from ``smartctl -a
+/dev/$device_namespace`` (for example ``smartctl -a /dev/nvme1n1``)
 indicate higher performance low level formats, with 0 being the best.
 The current formatting will be marked by a plus sign under the format
 Fmt.
 
-You may format a drive using \`nvme format /dev/nvme1n1 -l $ID`. The $ID
+You may format a drive using ``nvme format /dev/nvme1n1 -l $ID``. The $ID
 corresponds to the Id field value from the Supported LBA Sizes SMART
 information.
 
@@ -453,12 +455,12 @@ the drive firmware is not available for review, the traditional
 conclusion was that all drives that lack hardware features to avoid
 power failure events cannot be trusted, which was found to be the case
 multiple times in the
-past\ `1 <http://lkcl.net/reports/ssd_analysis.html>`__\ `2 <https://www.usenix.org/system/files/conference/fast13/fast13-final80.pdf>`__\ `3 <http://blog.nordeus.com/dev-ops/power-failure-testing-with-ssds.htm>`__.
+past [#ssd_analysis]_ [#ssd_analysis2]_ [#ssd_analysis3]_.
 Discussion of power failures bricking NAND flash SSDs appears to have
 vanished from literature following the year 2015. SSD manufacturers now
 claim that firmware power loss protection is robust enough to provide
-equivalent protection to hardware power loss protection. Kingston is one
-example\ `4 <https://www.kingston.com/us/solutions/servers-data-centers/ssd-power-loss-protection>`__.
+equivalent protection to hardware power loss protection. `Kingston is one
+example <https://www.kingston.com/us/solutions/servers-data-centers/ssd-power-loss-protection>`__.
 Firmware power loss protection is used to guarantee the protection of
 flushed data and the drives’ own metadata, which is all that filesystems
 such as ZFS need.
@@ -577,8 +579,8 @@ follows:
 -  Intel 320
 
    -  Early reports claimed that the 330 and 335 had power failure
-      protection too, but they do
-      not.\ `5 <http://blog.nordeus.com/dev-ops/power-failure-testing-with-ssds.htm>`__
+      protection too, `but they do
+      not <http://blog.nordeus.com/dev-ops/power-failure-testing-with-ssds.htm>`__.
 
 -  Intel 710
 -  Intel 730
@@ -594,8 +596,8 @@ follows:
 -  Samsung 845DC Evo
 -  Samsung 845DC Pro
 
-   -  High sustained write
-      IOPS\ `6 <http://www.anandtech.com/show/8319/samsung-ssd-845dc-evopro-preview-exploring-worstcase-iops/5>`__
+   -  `High sustained write
+      IOPS <http://www.anandtech.com/show/8319/samsung-ssd-845dc-evopro-preview-exploring-worstcase-iops/5>`__
 
 -  Toshiba HK4E/HK3E2
 -  Toshiba HK4R/HK3R2/HK3R
@@ -621,7 +623,7 @@ protects flushed data is sufficient for ZFS to ensure that data remains
 safe.
 
 Anyone who believes an unlisted drive to provide adequate power failure
-protection may contact the `OpenZFS mailing list <mailing_list>`__ with
+protection may contact the :ref:`mailing_lists` with
 a request for inclusion and substantiation for the claim that power
 failure protection is provided. Examples of substantiation include
 pictures of drive internals showing the presence of capacitors,
@@ -640,7 +642,7 @@ Flash pages
 The smallest unit on a NAND chip that can be written is a flash page.
 The first NAND-flash SSDs on the market had 4096-byte pages. Further
 complicating matters is that the the page size has been doubled twice
-since then. NAND flash SSDs \*should\* report these pages as being
+since then. NAND flash SSDs **should** report these pages as being
 sectors, but so far, all of them incorrectly report 512-byte sectors for
 Windows XP compatibility. The consequence is that we have a similar
 situation to what we had with early advanced format hard drives.
@@ -695,8 +697,8 @@ need to run TRIM on them. However, they cost more per GB than NAND flash
 (as of 2020). The enterprise models make excellent SLOG devices. Here is
 a list of models that are known to perform well:
 
--  Intel DC
-   P4800X\ `7 <https://www.servethehome.com/intel-optane-hands-on-real-world-benchmark-and-test-results/>`__
+-  `Intel DC
+   P4800X <https://www.servethehome.com/intel-optane-hands-on-real-world-benchmark-and-test-results/>`__
 
    -  This gives basically the highest performance you can get as of
       June 2020.
@@ -793,5 +795,13 @@ UPS batteries
 The lead acid batteries in UPS units generally need to be replaced
 regularly to ensure that they provide power during power outages. For
 home systems, this is every 3 to 5 years, although this varies with
-temperature\ `8 <https://www.apc.com/us/en/faqs/FA158934/>`__. For
+temperature [#ups_temp]_. For
 enterprise systems, contact your vendor.
+
+
+.. rubric:: Footnotes
+
+.. [#ssd_analysis] <http://lkcl.net/reports/ssd_analysis.html>
+.. [#ssd_analysis2] <https://www.usenix.org/system/files/conference/fast13/fast13-final80.pdf>
+.. [#ssd_analysis3] <http://blog.nordeus.com/dev-ops/power-failure-testing-with-ssds.htm>
+.. [#ups_temp] <https://www.apc.com/us/en/faqs/FA158934/>

--- a/docs/Performance and Tuning/Hardware.rst
+++ b/docs/Performance and Tuning/Hardware.rst
@@ -128,7 +128,7 @@ things to note:
    -  This configuration is typically not tested.
    -  The disks could be unrecognized.
 
--  Support for SATA port multipliers is inconsistent across Open ZFS
+-  Support for SATA port multipliers is inconsistent across OpenZFS
    platforms
 
    -  Linux drivers generally support them.
@@ -152,7 +152,7 @@ Controllers
 
 The ideal storage controller for ZFS has the following attributes:
 
--  Driver support on major Open ZFS platforms
+-  Driver support on major OpenZFS platforms
 
    -  Stability is important.
 
@@ -391,7 +391,7 @@ requires command queuing. Almost all drives manufactured within the past
 -  SATA drives operating under IDE emulation that was configured in the
    system BIOS.
 
-Each Open ZFS system has different methods for checking whether command
+Each OpenZFS system has different methods for checking whether command
 queuing is supported. On Linux, ``hdparm -I /path/to/device \| grep
 Queue`` is used. On FreeBSD, ``camcontrol identify $DEVICE`` is used.
 
@@ -654,7 +654,7 @@ As of 2014, most NAND-flash SSDs on the market have 8192-byte page
 sizes. However, models using 128-Gbit NAND from certain manufacturers
 have a 16384-byte page size. Maximum performance requires that vdevs be
 created with correct ashift values (13 for 8192-byte and 14 for
-16384-byte). However, not all Open ZFS platforms support this. The Linux
+16384-byte). However, not all OpenZFS platforms support this. The Linux
 port supports ashift=13, while others are limited to ashift=12
 (4096-byte).
 

--- a/docs/Performance and Tuning/Workload Tuning.rst
+++ b/docs/Performance and Tuning/Workload Tuning.rst
@@ -3,6 +3,9 @@ Workload Tuning
 
 Below are tips for various workloads.
 
+.. contents:: Table of Contents
+  :local:
+
 .. _basic_concepts:
 
 Basic concepts

--- a/docs/Performance and Tuning/Workload Tuning.rst
+++ b/docs/Performance and Tuning/Workload Tuning.rst
@@ -1,0 +1,685 @@
+Below are tips for various workloads.
+
+.. _basic_concepts:
+
+Basic concepts
+--------------
+
+Descriptions of ZFS internals that have an effect on application
+performance follow.
+
+.. _adaptive_replacement_cache:
+
+Adaptive Replacement Cache
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For decades, operating systems have used RAM as a cache to avoid the
+necessity of waiting on disk IO, which is extremely slow. This concept
+is called page replacement. Until ZFS, virtually all filesystems used
+the Least Recently Used (LRU) page replacement algorithm in which the
+least recently used pages are the first to be replaced. Unfortunately,
+the LRU algorithm is vulnerable to cache flushes, where a brief change
+in workload that occurs occasionally removes all frequently used data
+from cache. The Adaptive Replacement Cache (ARC) algorithm was
+implemented in ZFS to replace LRU. It solves this problem by maintaining
+four lists:
+
+#. A list for recently cached entries.
+#. A list for recently cached entries that have been accessed more than
+   once.
+#. A list for entries evicted from #1.
+#. A list of entries evicited from #2.
+
+Data is evicted from the first list while an effort is made to keep data
+in the second list. In this way, ARC is able to outperform LRU by
+providing a superior hit rate.
+
+In addition, a dedicated cache device (typically a SSD) can be added to
+the pool, with
+``zpool add``\ *``poolname``*\ ``cache``\ *``devicename``*. The cache
+device is managed by the L2ARC, which scans entries that are next to be
+evicted and writes them to the cache device. The data stored in ARC and
+L2ARC can be controlled via the ``primarycache`` and ``secondarycache``
+zfs properties respectively, which can be set on both zvols and
+datasets. Possible settings are ``all``, ``none`` and ``metadata``. It
+is possible to improve performance when a zvol or dataset hosts an
+application that does its own caching by caching only metadata. One
+example is PostgreSQL. Another would be a virtual machine using ZFS.
+
+.. _alignment_shift_ashift:
+
+Alignment Shift (ashift)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Top-level vdevs contain an internal property called ashift, which stands
+for alignment shift. It is set at vdev creation and it is immutable. It
+can be read using the ``zdb`` command. It is calculated as the maximum
+base 2 logarithm of the physical sector size of any child vdev and it
+alters the disk format such that writes are always done according to it.
+This makes 2^ashift the smallest possible IO on a vdev. Configuring
+ashift correctly is important because partial sector writes incur a
+penalty where the sector must be read into a buffer before it can be
+written. ZFS makes the implicit assumption that the sector size reported
+by drives is correct and calculates ashift based on that.
+
+In an ideal world, physical sector size is always reported correctly and
+therefore, this requires no attention. Unfortunately, this is not the
+case. The sector size on all storage devices was 512-bytes prior to the
+creation of flash-based solid state drives. Some operating systems, such
+as Windows XP, were written under this assumption and will not function
+when drives report a different sector size.
+
+Flash-based solid state drives came to market around 2007. These devices
+report 512-byte sectors, but the actual flash pages, which roughly
+correspond to sectors, are never 512-bytes. The early models used
+4096-byte pages while the newer models have moved to an 8192-byte page.
+In addition, "Advanced Format" hard drives have been created which also
+use a 4096-byte sector size. Partial page writes suffer from similar
+performance degradation as partial sector writes. In some cases, the
+design of NAND-flash makes the performance degradation even worse, but
+that is beyond the scope of this description.
+
+Reporting the correct sector sizes is the responsibility the block
+device layer. This unfortunately has made proper handling of devices
+that misreport drives different across different platforms. The
+respective methods are as follows:
+
+-  `sd.conf <http://wiki.illumos.org/display/illumos/ZFS+and+Advanced+Format+disks#ZFSandAdvancedFormatdisks-OverridingthePhysicalBlockSize>`__
+   on illumos
+-  `gnop(8) <https://www.freebsd.org/cgi/man.cgi?query=gnop&sektion=8&manpath=FreeBSD+10.2-RELEASE>`__
+   on FreeBSD; see for example `FreeBSD on 4K sector
+   drives <http://web.archive.org/web/20151022020605/http://ivoras.sharanet.org/blog/tree/2011-01-01.freebsd-on-4k-sector-drives.html>`__
+   (2011-01-01)
+-  `ashift= <https://openzfs.github.io/openzfs-docs/Project%20and%20Community/FAQ.html#advanced-format-disks-o>`__
+   on ZFS on Linux
+-  -o ashift= also works with both MacZFS (pool version 8) and ZFS-OSX
+   (pool version 5000).
+
+-o ashift= is convenient, but it is flawed in that the creation of pools
+containing top level vdevs that have multiple optimal sector sizes
+require the use of multiple commands. `A newer
+syntax <http://www.listbox.com/member/archive/182191/2013/07/search/YXNoaWZ0/sort/time_rev/page/2/entry/16:58/20130709002459:82E21654-E84F-11E2-A0FF-F6B47351D2F5/>`__
+that will rely on the actual sector sizes has been discussed as a cross
+platform replacement and will likely be implemented in the future.
+
+In addition, `Richard Yao <User:Ryao>`__ has contributed a `database of
+drives known to misreport sector
+sizes <https://github.com/openzfs/zfs/blob/master/cmd/zpool/os/linux/zpool_vdev_os.c#L98>`__
+to the ZFS on Linux project. It is used to automatically adjust ashift
+without the assistance of the system administrator. This approach is
+unable to fully compensate for misreported sector sizes whenever drive
+identifiers are used ambiguously (e.g. virtual machines, iSCSI LUNs,
+some rare SSDs), but it does a great amount of good. The format is
+roughly compatible with illumos' sd.conf and it is expected that other
+implementations will integrate the database in future releases. Strictly
+speaking, this database does not belong in ZFS, but the difficulty of
+patching the Linux kernel (especially older ones) necessitated that this
+be implemented in ZFS itself for Linux. The same is true for MacZFS.
+However, FreeBSD and illumos are both able to implement this in the
+correct layer.
+
+Compression
+~~~~~~~~~~~
+
+Internally, ZFS allocates data using multiples of the device's sector
+size, typically either 512 bytes or 4KB (see above). When compression is
+enabled, a smaller number of sectors can be allocated for each block.
+The uncompressed block size is set by the ``recordsize`` (defaults to
+128KB) or ``volblocksize`` (defaults to 8KB) property (for filesystems
+vs volumes).
+
+The following compression algorithms are available:
+
+-  LZ4
+
+   -  New algorithm added after feature flags were created. It is
+      significantly superior to LZJB in all metrics tested. It is new
+      default compression algorithm (compression=on) in
+      OpenZFS\ `1 <https://github.com/illumos/illumos-gate/commit/db1741f555ec79def5e9846e6bfd132248514ffe>`__.
+      It is available on all platforms have as of 2020.
+
+-  LZJB
+
+   -  Original default compression algorithm (compression=on) for ZFS.
+      It was created to satisfy the desire for a compression algorithm
+      suitable for use in filesystems. Specifically, that it provides
+      fair compression, has a high compression speed, has a high
+      decompression speed and detects incompressible data detection
+      quickly.
+
+-  GZIP (1 through 9)
+
+   -  Classic Lempel-Ziv implementation. It provides high compression,
+      but it often makes IO CPU-bound.
+
+-  ZLE (Zero Length Encoding)
+
+   -  A very simple algorithm that only compresses zeroes.
+
+If you want to use compression and are uncertain which to use, use LZ4.
+It averages a 2.1:1 compression ratio while gzip-1 averages 2.7:1, but
+gzip is much slower. Both figures are obtained from `testing by the LZ4
+project <https://code.google.com/p/lz4/>`__ on the Silesia corpus. The
+greater compression ratio of gzip is usually only worthwhile for rarely
+accessed data.
+
+.. _raid_z_stripe_width:
+
+RAID-Z stripe width
+~~~~~~~~~~~~~~~~~~~
+
+Choose a RAID-Z stripe width based on your IOPS needs and the amount of
+space you are willing to devote to parity information. If you need more
+IOPS, use fewer disks per stripe. If you need more usable space, use
+more disks per stripe. Trying to optimize your RAID-Z stripe width based
+on exact numbers is irrelevant in nearly all cases. See this `blog
+post <https://www.delphix.com/blog/delphix-engineering/zfs-raidz-stripe-width-or-how-i-learned-stop-worrying-and-love-raidz/>`__
+for more details.
+
+.. _dataset_recordsize:
+
+Dataset recordsize
+~~~~~~~~~~~~~~~~~~
+
+ZFS datasets use an internal recordsize of 128KB by default. The dataset
+recordsize is the basic unit of data used for internal copy-on-write on
+files. Partial record writes require that data be read from either ARC
+(cheap) or disk (expensive). recordsize can be set to any power of 2
+from 512 bytes to 128 kilobytes. Software that writes in fixed record
+sizes (e.g. databases) will benefit from the use of a matching
+recordsize.
+
+Changing the recordsize on a dataset will only take effect for new
+files. If you change the recordsize because your application should
+perform better with a different one, you will need to recreate its
+files. A cp followed by a mv on each file is sufficient. Alternatively,
+send/recv should recreate the files with the correct recordsize when a
+full receive is done.
+
+.. _larger_record_sizes:
+
+Larger record sizes
+^^^^^^^^^^^^^^^^^^^
+
+Record sizes of up to 16M are supported with the large_blocks pool
+feature, which is enabled by default on new pools on systems that
+support it. However, record sizes larger than 1M is disabled by default
+unless the zfs_max_recordsize kernel module parameter is set to allow
+sizes higher than 1M. Larger record sizes than 1M are not well tested as
+1M, although they should work. \`zfs send\` operations must specify -L
+to ensure that larger than 128KB blocks are sent and the receiving pools
+must support the large_blocks feature.
+
+.. _zvol_volblocksize:
+
+zvol volblocksize
+~~~~~~~~~~~~~~~~~
+
+Zvols have a volblocksize property that is analogous to record size. The
+default size is 8KB, which is the size of a page on the SPARC
+architecture. Workloads that use smaller sized IOs (such as swap on x86
+which use 4096-byte pages) will benefit from a smaller volblocksize.
+
+Deduplication
+~~~~~~~~~~~~~
+
+Deduplication uses an on-disk hash table, using `extensible
+hashing <http://en.wikipedia.org/wiki/Extensible_hashing>`__ as
+implemented in the ZAP (ZFS Attribute Processor). Each cached entry uses
+slightly more than 320 bytes of memory. The DDT code relies on ARC for
+caching the DDT entries, such that there is no double caching or
+internal fragmentation from the kernel memory allocator. Each pool has a
+global deduplication table shared across all datasets and zvols on which
+deduplication is enabled. Each entry in the hash table is a record of a
+unique block in the pool. (Where the block size is set by the
+``recordsize`` or ``volblocksize`` properties.)
+
+The hash table (also known as the DDT or DeDup Table) must be accessed
+for every dedup-able block that is written or freed (regardless of
+whether it has multiple references). If there is insufficient memory for
+the DDT to be cached in memory, each cache miss will require reading a
+random block from disk, resulting in poor performance. For example, if
+operating on a single 7200RPM drive that can do 100 io/s, uncached DDT
+reads would limit overall write throughput to 100 blocks per second, or
+400KB/s with 4KB blocks.
+
+The consequence is that sufficient memory to store deduplication data is
+required for good performance. The deduplication data is considered
+metadata and therefore can be cached if the ``primarycache`` or
+``secondarycache`` properties are set to ``metadata``. In addition, the
+deduplication table will compete with other metadata for metadata
+storage, which can have a negative effect on performance. Simulation of
+the number of deduplication table entries needed for a given pool can be
+done using the -D option to zdb. Then a simple multiplication by
+320-bytes can be done to get the approximate memory requirements.
+Alternatively, you can estimate an upper bound on the number of unique
+blocks by dividing the amount of storage you plan to use on each dataset
+(taking into account that partial records each count as a full
+recordsize for the purposes of deduplication) by the recordsize and each
+zvol by the volblocksize, summing and then multiplying by 320-bytes.
+
+.. _metaslab_allocator:
+
+Metaslab Allocator
+~~~~~~~~~~~~~~~~~~
+
+ZFS top level vdevs are divided into metaslabs from which blocks can be
+independently allocated so allow for concurrent IOs to perform
+allocations without blocking one another. At present, there is a
+regression\ `2 <https://github.com/zfsonlinux/zfs/pull/3643>`__ on the
+Linux and Mac OS X ports that causes serialization to occur.
+
+By default, the selection of a metaslab is biased toward lower LBAs to
+improve performance of spinning disks, but this does not make sense on
+solid state media. This behavior can be adjusted globally by setting the
+ZFS module's global metaslab_lba_weighting_enabled tuanble to 0. This
+tunable is only advisable on systems that only use solid state media for
+pools.
+
+The metaslab allocator will allocate blocks on a first-fit basis when a
+metaslab has more than or equal to 4 percent free space and a best-fit
+basis when a metaslab has less than 4 percent free space. The former is
+much faster than the latter, but it is not possible to tell when this
+behavior occurs from the pool's free space. However, the command \`zdb
+-mmm $POOLNAME\` will provide this information.
+
+.. _pool_geometry:
+
+Pool Geometry
+~~~~~~~~~~~~~
+
+If small random IOPS are of primary importance, mirrored vdevs will
+outperform raidz vdevs. Read IOPS on mirrors will scale with the number
+of drives in each mirror while raidz vdevs will each be limited to the
+IOPS of the slowest drive.
+
+If sequential writes are of primary importance, raidz will outperform
+mirrored vdevs. Sequential write throughput increases linearly with the
+number of data disks in raidz while writes are limited to the slowest
+drive in mirrored vdevs. Sequential read performance should be roughly
+the same on each.
+
+Both IOPS and throughput will increase by the respective sums of the
+IOPS and throughput of each top level vdev, regardless of whether they
+are raidz or mirrors.
+
+.. _whole_disks_versus_partitions:
+
+Whole Disks versus Partitions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ZFS will behave differently on different platforms when given a whole
+disk.
+
+On illumos, ZFS attempts to enable the write cache on a whole disk. The
+illumos UFS driver cannot ensure integrity with the write cache enabled,
+so by default Sun/Solaris systems using UFS file system for boot were
+shipped with drive write cache disabled (long ago, when Sun was still an
+independent company). For safety on illumos, if ZFS is not given the
+whole disk, it could be shared with UFS and thus it is not appropriate
+for ZFS to enable write cache. In this case, the write cache setting is
+not changed and will remain as-is. Today, most vendors ship drives with
+write cache enabled by default.
+
+On Linux, the Linux IO elevator is largely redundant given that ZFS has
+its own IO elevator, so ZFS will set the IO elevator to noop to avoid
+unnecessary CPU overhead.
+
+ZFS will also create a GPT partition table own partitions when given a
+whole disk under illumos on x86/amd64 and on Linux. This is mainly to
+make booting through UEFI possible because UEFI requires a small FAT
+partition to be able to boot the system. The ZFS driver will be able to
+tell the difference between whether the pool had been given the entire
+disk or not via the whole_disk field in the label.
+
+This is not done on FreeBSD. Pools created by FreeBSD will always have
+the whole_disk field set to true, such that a pool imported on another
+platform that was created on FreeBSD will always be treated as the whole
+disks were given to ZFS.
+
+.. _general_recommendations:
+
+General recommendations
+-----------------------
+
+.. _alignment_shift:
+
+Alignment shift
+~~~~~~~~~~~~~~~
+
+Make sure that you create your pools such that the vdevs have the
+correct alignment shift for your storage device's size. if dealing with
+flash media, this is going to be either 12 (4K sectors) or 13 (8K
+sectors). For SSD ephemeral storage on Amazon EC2, the proper setting is
+12.
+
+.. _atime_updates:
+
+Atime Updates
+~~~~~~~~~~~~~
+
+Set either relatime=on or atime=off to minimize IOs used to update
+access time stamps. For backward compatibility with a small percentage
+of software that supports it, relatime is preferred when available and
+should be set on your entire pool. atime=off should be used more
+selectively.
+
+.. _free_space:
+
+Free Space
+~~~~~~~~~~
+
+Keep pool free space above 10% to avoid many metaslabs from reaching the
+4% free space threshold to switch from first-fit to best-fit allocation
+strategies. When the threshold is hit, the `metaslab
+allocator <Performance_tuning#Metaslab_Allocator>`__ becomes very CPU
+intensive in an attempt to protect itself from fragmentation. This
+reduces IOPS, especially as more metaslabs reach the 4% threshold.
+
+The recommendation is 10% rather than 5% because metaslabs selection
+considers both location and free space unless the global
+metaslab_lba_weighting_enabled tunable is set to 0. When that tunable is
+0, ZFS will consider only free space, so the the expense of the best-fit
+allocator can be avoided by keeping free space above 5%. That setting
+should only be used on systems with pools that consist of solid state
+drives because it will reduce sequential IO performance on mechanical
+disks.
+
+.. _lz4_compression:
+
+LZ4 compression
+~~~~~~~~~~~~~~~
+
+Set compression=lz4 on your pools' root datasets so that all datasets
+inherit it unless you have a reason not to enable it. Userland tests of
+LZ4 compression of incompressible data in a single thread has shown that
+it can process 10GB/sec, so it is unlikely to be a bottleneck even on
+incompressible data. Furthermore, incompressible data will be stored
+without compression such that reads of incompressible data with
+compression enabled will not be subject to decompression. Writes are so
+fast that in-compressible data is unlikely to see a performance penalty
+from the use of LZ4 compression. The reduction in IO from LZ4 will
+typically be a performance win.
+
+Note that larger record sizes will increase compression ratios on
+compressible data by allowing compression algorithms to process more
+data at a time.
+
+.. _nvme_low_level_formatting:
+
+NVMe low level formatting
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+See
+`Hardware#NVMe_low_level_formatting <Hardware#NVMe_low_level_formatting>`__.
+
+.. _pool_geometry_1:
+
+Pool Geometry
+~~~~~~~~~~~~~
+
+Do not put more than ~16 disks in raidz. The rebuild times on mechanical
+disks will be excessive when the pool is full.
+
+.. _synchronous_io:
+
+Synchronous I/O
+~~~~~~~~~~~~~~~
+
+If your workload involves fsync or O_SYNC and your pool is backed by
+mechanical storage, consider adding one or more SLOG devices. Pools that
+have multiple SLOG devices will distribute ZIL operations across them.
+The best choice for SLOG device(s) are likely Optane / 3D XPoint SSDs.
+See
+`Hardware#Optane_.2F_3D_XPoint_SSDs <Hardware#Optane_.2F_3D_XPoint_SSDs>`__
+for a description of them. If an Optane / 3D XPoint SSD is an option,
+the rest of this section on synchronous I/O need not be read. If Optane
+/ 3D XPoint SSDs is not an option, see
+`Hardware#NAND_Flash_SSDs <Hardware#NAND_Flash_SSDs>`__ for suggestions
+for NAND flash SSDs and also read the information below.
+
+To ensure maximum ZIL performance on NAND flash SSD-based SLOG devices,
+you should also overprovison spare area to increase
+IOPS\ `3 <http://www.anandtech.com/show/6489/playing-with-op>`__. Only
+about 4GB is needed, so the rest can be left as overprovisioned storage.
+The choice of 4GB is somewhat arbitrary. Most systems do not write
+anything close to 4GB to ZIL between transaction group commits, so
+overprovisioning all storage beyond the 4GB partition should be alright.
+If a workload needs more, then make it no more than the maximum ARC
+size. Even under extreme workloads, ZFS will not benefit from more SLOG
+storage than the maximum ARC size. That is half of system memory on
+Linux and 3/4 of system memory on illumos.
+
+.. _overprovisioning_by_secure_erase_and_partition_table_trick:
+
+Overprovisioning by secure erase and partition table trick
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can do this with a mix of a secure erase and a partition table
+trick, such as the following:
+
+#. Run a secure erase on the NAND-flash SSD.
+#. Create a partition table on the NAND-flash SSD.
+#. Create a 4GB partition.
+#. Give the partition to ZFS to use as a log device.
+
+If using the secure erase and partition table trick, do *not* use the
+unpartitioned space for other things, even temporarily. That will reduce
+or eliminate the overprovisioning by marking pages as dirty.
+
+Alternatively, some devices allow you to change the sizes that they
+report.This would also work, although a secure erase should be done
+prior to changing the reported size to ensure that the SSD recognizes
+the additional spare area. Changing the reported size can be done on
+drives that support it with \`hdparm -N \` on systems that have
+laptop-mode-tools.
+
+.. _nvme_overprovisioning:
+
+NVMe overprovisioning
+^^^^^^^^^^^^^^^^^^^^^
+
+On NVMe, you can use namespaces to achieve overprovisioning:
+
+#. Do a sanitize command as a precaution to ensure the device is
+   completely clean.
+#. Delete the default namespace.
+#. Create a new namespace of size 4GB.
+#. Give the namespace to ZFS to use as a log device. e.g. zfs add tank
+   log /dev/nvme1n1
+
+.. _whole_disks:
+
+Whole disks
+~~~~~~~~~~~
+
+Whole disks should be given to ZFS rather than partitions. If you must
+use a partition, make certain that the partition is properly aligned to
+avoid read-modify-write overhead. See the section on `Alignment
+Shift <Performance_tuning#Alignment_Shift_.28ashift.29>`__ for a
+description of proper alignment. Also, see the section on `Whole Disks
+versus Partitions <Performance_tuning#Whole_Disks_versus_Partitions>`__
+for a description of changes in ZFS behavior when operating on a
+partition.
+
+Single disk RAID 0 arrays from RAID controllers are not equivalent to
+whole disks. The `Hardware <Hardware#Hardware_RAID_controllers>`__ page
+explains in detail.
+
+.. _bit_torrent:
+
+Bit Torrent
+-----------
+
+Bit torrent performs 16KB random reads/writes. The 16KB writes cause
+read-modify-write overhead. The read-modify-write overhead can reduce
+performance by a factor of 16 with 128KB record sizes when the amount of
+data written exceeds system memory. This can be avoided by using a
+dedicated dataset for bit torrent downloads with recordsize=16KB.
+
+When the files are read sequentially through a HTTP server, the random
+nature in which the files were generated creates fragmentation that has
+been observed to reduce sequential read performance by a factor of two
+on 7200RPM hard disks. If performance is a problem, fragmentation can be
+eliminated by rewriting the files sequentially in either of two ways:
+
+The first method is to configure your client to download the files to a
+temporary directory and then copy them into their final location when
+the downloads are finished, provided that your client supports this.
+
+The second method is to use send/recv to recreate a dataset
+sequentially.
+
+In practice, defragmenting files obtained through bit torrent should
+only improve performance when the files are stored on magnetic storage
+and are subject to significant sequential read workloads after creation.
+
+.. _database_workloads:
+
+Database workloads
+------------------
+
+Setting redundant_metadata=mostly can increase IOPS by at least a few
+percentage points by eliminating redundant metadata at the lowest level
+of the indirect block tree. This comes with the caveat that data loss
+will occur if a metadata block pointing to data blocks is corrupted and
+there are no duplicate copies, but this is generally not a problem in
+production on mirrored or raidz vdevs.
+
+MySQL
+~~~~~
+
+InnoDB
+^^^^^^
+
+Make separate datasets for InnoDB's data files and log files. Set
+recordsize=16K on InnoDB's data files to avoid expensive partial record
+writes and leave recordsize=128K on the log files. Set
+primarycache=metadata on both to prefer InnoDB's
+caching.\ `4 <https://www.patpro.net/blog/index.php/2014/03/09/2617-mysql-on-zfs-on-freebsd/>`__
+Set logbias=throughput on the data to stop ZIL from writing twice.
+
+Set skip-innodb_doublewrite in my.cnf to prevent innodb from writing
+twice. The double writes are a data integrity feature meant to protect
+against corruption from partially-written records, but those are not
+possible on ZFS. It should be noted that Percona’s
+blog\ `5 <https://www.percona.com/blog/2014/05/23/improve-innodb-performance-write-bound-loads/>`__
+had advocated using an ext4 configuration where double writes were
+turned off for a performance gain, but later recanted it because it
+caused data corruption. Following a well timed power failure, an in
+place filesystem such as ext4 can have half of a 8KB record be old while
+the other half would be new. This would be the corruption that caused
+Percona to recant its advice. However, ZFS’ copy on write design would
+cause it to return the old correct data following a power failure (no
+matter what the timing is). That prevents the corruption that the double
+write feature is intended to prevent from ever happening. The double
+write feature is therefore unnecessary on ZFS and can be safely turned
+off for better performance.
+
+On Linux, the driver's AIO implementation is a compatibility shim that
+just barely passes the POSIX standard. InnoDB performance suffers when
+using its default AIO codepath. Set innodb_use_native_aio=0 and
+innodb_use_atomic_writes=0 in my.cnf to disable AIO. Both of these
+settings must be disabled to disable AIO.
+
+PostgreSQL
+~~~~~~~~~~
+
+Make separate datasets for PostgreSQL's data and WAL. Set recordsize=8K
+on both to avoid expensive partial record writes. Set logbias=throughput
+on PostgreSQL's data to avoid writing twice.
+
+SQLite
+~~~~~~
+
+Make a separate dataset for the database. Set the recordsize to 64K. Set
+the SQLite page size to 65536
+bytes\ `6 <https://www.sqlite.org/pragma.html#pragma_page_size>`__.
+
+Note that SQLite databases typically are not exercised enough to merit
+special tuning, but this will provide it. Note the side effect on cache
+size mentioned at
+SQLite.org\ `7 <https://www.sqlite.org/pgszchng2016.html>`__.
+
+.. _file_servers:
+
+File servers
+------------
+
+Create a dedicated dataset for files being served.
+
+See
+`Performance_tuning#Sequential_workloads <Performance_tuning#Sequential_workloads>`__
+for configuration recommendations.
+
+.. _sequential_workloads:
+
+Sequential workloads
+--------------------
+
+Set recordsize=1M on datasets that are subject to sequential workloads.
+Read
+`Performance_tuning#Larger_record_sizes <Performance_tuning#Larger_record_sizes>`__
+for documentation on things that should be known before setting 1M
+record sizes.
+
+Set compression=lz4 as per the general recommendation for `LZ4
+compression <Performance_tuning#LZ4_compression>`__.
+
+.. _video_games_directories:
+
+Video games directories
+-----------------------
+
+Create a dedicated dataset, use chown to make it user accessible (or
+create a directory under it and use chown on that) and then configure
+the game download application to place games there. Specific information
+on how to configure various ones is below.
+
+See
+`Performance_tuning#Sequential_workloads <Performance_tuning#Sequential_workloads>`__
+for configuration recommendations before installing games.
+
+Note that the performance gains from this tuning are likely to be small
+and limited to load times. However, the combination of 1M records and
+LZ4 will allow more games to be stored, which is why this tuning is
+documented despite the performance gains being limited. A steam library
+of 300 games (mostly from humble bundle) that had these tweaks applied
+to it saw 20% space savings. Both faster load times and significant
+space savings are possible on compressible games when this tuning has
+been done. Games whose assets are already compressed will see little to
+no benefit.
+
+Lutris
+~~~~~~
+
+Open the context menu by left clicking on the triple bar icon in the
+upper right. Go to "Preferences" and then the "System options" tab.
+Change the default installation directory and click save.
+
+Steam
+~~~~~
+
+Go to "Settings" -> "Downloads" -> "Steam Library Folders" and use "Add
+Library Folder" to set the directory for steam to use to store games.
+Make sure to set it to the default by right clicking on it and clicking
+"Make Default Folder" before closing the dialogue.
+
+.. _virtual_machines:
+
+Virtual machines
+----------------
+
+Virtual machine images on ZFS should be stored using either zvols or raw
+files to avoid unnecessary overhead. The recordsize/volblocksize and
+guest filesystem should be configured to match to avoid overhead from
+partial record modification. This would typically be 4K. If raw files
+are used, a separate dataset should be used to make it easy to configure
+recordsize independently of other things stored on ZFS.
+
+.. _qemu_kvm_xen:
+
+QEMU / KVM / Xen
+~~~~~~~~~~~~~~~~
+
+AIO should be used to maximize IOPS when using files for guest storage.

--- a/docs/Performance and Tuning/Workload Tuning.rst
+++ b/docs/Performance and Tuning/Workload Tuning.rst
@@ -1,3 +1,6 @@
+Workload Tuning
+===============
+
 Below are tips for various workloads.
 
 .. _basic_concepts:
@@ -36,7 +39,7 @@ providing a superior hit rate.
 
 In addition, a dedicated cache device (typically a SSD) can be added to
 the pool, with
-``zpool add``\ *``poolname``*\ ``cache``\ *``devicename``*. The cache
+``zpool add POOLNAME cache DEVICENAME``. The cache
 device is managed by the L2ARC, which scans entries that are next to be
 evicted and writes them to the cache device. The data stored in ARC and
 L2ARC can be controlled via the ``primarycache`` and ``secondarycache``
@@ -90,7 +93,7 @@ respective methods are as follows:
    on FreeBSD; see for example `FreeBSD on 4K sector
    drives <http://web.archive.org/web/20151022020605/http://ivoras.sharanet.org/blog/tree/2011-01-01.freebsd-on-4k-sector-drives.html>`__
    (2011-01-01)
--  `ashift= <https://openzfs.github.io/openzfs-docs/Project%20and%20Community/FAQ.html#advanced-format-disks-o>`__
+-  `ashift= <https://openzfs.github.io/openzfs-docs/Project%20and%20Community/FAQ.html#advanced-format-disks>`__
    on ZFS on Linux
 -  -o ashift= also works with both MacZFS (pool version 8) and ZFS-OSX
    (pool version 5000).
@@ -102,7 +105,7 @@ syntax <http://www.listbox.com/member/archive/182191/2013/07/search/YXNoaWZ0/sor
 that will rely on the actual sector sizes has been discussed as a cross
 platform replacement and will likely be implemented in the future.
 
-In addition, `Richard Yao <User:Ryao>`__ has contributed a `database of
+In addition, there is a `database of
 drives known to misreport sector
 sizes <https://github.com/openzfs/zfs/blob/master/cmd/zpool/os/linux/zpool_vdev_os.c#L98>`__
 to the ZFS on Linux project. It is used to automatically adjust ashift
@@ -133,9 +136,9 @@ The following compression algorithms are available:
 -  LZ4
 
    -  New algorithm added after feature flags were created. It is
-      significantly superior to LZJB in all metrics tested. It is new
-      default compression algorithm (compression=on) in
-      OpenZFS\ `1 <https://github.com/illumos/illumos-gate/commit/db1741f555ec79def5e9846e6bfd132248514ffe>`__.
+      significantly superior to LZJB in all metrics tested. It is `new
+      default compression algorithm <https://github.com/illumos/illumos-gate/commit/db1741f555ec79def5e9846e6bfd132248514ffe>`__
+      (compression=on) in OpenZFS.
       It is available on all platforms have as of 2020.
 
 -  LZJB
@@ -159,7 +162,7 @@ The following compression algorithms are available:
 If you want to use compression and are uncertain which to use, use LZ4.
 It averages a 2.1:1 compression ratio while gzip-1 averages 2.7:1, but
 gzip is much slower. Both figures are obtained from `testing by the LZ4
-project <https://code.google.com/p/lz4/>`__ on the Silesia corpus. The
+project <https://github.com/lz4/lz4>`__ on the Silesia corpus. The
 greater compression ratio of gzip is usually only worthwhile for rarely
 accessed data.
 
@@ -265,8 +268,8 @@ Metaslab Allocator
 
 ZFS top level vdevs are divided into metaslabs from which blocks can be
 independently allocated so allow for concurrent IOs to perform
-allocations without blocking one another. At present, there is a
-regression\ `2 <https://github.com/zfsonlinux/zfs/pull/3643>`__ on the
+allocations without blocking one another. At present, `there is a
+regression <https://github.com/zfsonlinux/zfs/pull/3643>`__ on the
 Linux and Mac OS X ports that causes serialization to occur.
 
 By default, the selection of a metaslab is biased toward lower LBAs to
@@ -280,8 +283,8 @@ The metaslab allocator will allocate blocks on a first-fit basis when a
 metaslab has more than or equal to 4 percent free space and a best-fit
 basis when a metaslab has less than 4 percent free space. The former is
 much faster than the latter, but it is not possible to tell when this
-behavior occurs from the pool's free space. However, the command \`zdb
--mmm $POOLNAME\` will provide this information.
+behavior occurs from the pool's free space. However, the command ``zdb
+-mmm $POOLNAME`` will provide this information.
 
 .. _pool_geometry:
 
@@ -371,8 +374,7 @@ Free Space
 
 Keep pool free space above 10% to avoid many metaslabs from reaching the
 4% free space threshold to switch from first-fit to best-fit allocation
-strategies. When the threshold is hit, the `metaslab
-allocator <Performance_tuning#Metaslab_Allocator>`__ becomes very CPU
+strategies. When the threshold is hit, the :ref:`metaslab_allocator` becomes very CPU
 intensive in an attempt to protect itself from fragmentation. This
 reduces IOPS, especially as more metaslabs reach the 4% threshold.
 
@@ -405,13 +407,12 @@ Note that larger record sizes will increase compression ratios on
 compressible data by allowing compression algorithms to process more
 data at a time.
 
-.. _nvme_low_level_formatting:
+.. _nvme_low_level_formatting_link:
 
 NVMe low level formatting
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-See
-`Hardware#NVMe_low_level_formatting <Hardware#NVMe_low_level_formatting>`__.
+See :ref:`nvme_low_level_formatting`.
 
 .. _pool_geometry_1:
 
@@ -430,17 +431,16 @@ If your workload involves fsync or O_SYNC and your pool is backed by
 mechanical storage, consider adding one or more SLOG devices. Pools that
 have multiple SLOG devices will distribute ZIL operations across them.
 The best choice for SLOG device(s) are likely Optane / 3D XPoint SSDs.
-See
-`Hardware#Optane_.2F_3D_XPoint_SSDs <Hardware#Optane_.2F_3D_XPoint_SSDs>`__
+See :ref:`optane_3d_xpoint_ssds`
 for a description of them. If an Optane / 3D XPoint SSD is an option,
 the rest of this section on synchronous I/O need not be read. If Optane
 / 3D XPoint SSDs is not an option, see
-`Hardware#NAND_Flash_SSDs <Hardware#NAND_Flash_SSDs>`__ for suggestions
+:ref:`nand_flash_ssds` for suggestions
 for NAND flash SSDs and also read the information below.
 
 To ensure maximum ZIL performance on NAND flash SSD-based SLOG devices,
 you should also overprovison spare area to increase
-IOPS\ `3 <http://www.anandtech.com/show/6489/playing-with-op>`__. Only
+IOPS [#ssd_iops]_. Only
 about 4GB is needed, so the rest can be left as overprovisioned storage.
 The choice of 4GB is somewhat arbitrary. Most systems do not write
 anything close to 4GB to ZIL between transaction group commits, so
@@ -495,15 +495,15 @@ Whole disks
 
 Whole disks should be given to ZFS rather than partitions. If you must
 use a partition, make certain that the partition is properly aligned to
-avoid read-modify-write overhead. See the section on `Alignment
-Shift <Performance_tuning#Alignment_Shift_.28ashift.29>`__ for a
-description of proper alignment. Also, see the section on `Whole Disks
-versus Partitions <Performance_tuning#Whole_Disks_versus_Partitions>`__
+avoid read-modify-write overhead. See the section on
+:ref:`Alignment Shift (ashift) <alignment_shift_ashift>`
+for a description of proper alignment. Also, see the section on
+:ref:`Whole Disks versus Partitions <whole_disks_versus_partitions>`
 for a description of changes in ZFS behavior when operating on a
 partition.
 
 Single disk RAID 0 arrays from RAID controllers are not equivalent to
-whole disks. The `Hardware <Hardware#Hardware_RAID_controllers>`__ page
+whole disks. The :ref:`hardware_raid_controllers` page
 explains in detail.
 
 .. _bit_torrent:
@@ -539,7 +539,7 @@ and are subject to significant sequential read workloads after creation.
 Database workloads
 ------------------
 
-Setting redundant_metadata=mostly can increase IOPS by at least a few
+Setting ``redundant_metadata=mostly`` can increase IOPS by at least a few
 percentage points by eliminating redundant metadata at the lowest level
 of the indirect block tree. This comes with the caveat that data loss
 will occur if a metadata block pointing to data blocks is corrupted and
@@ -553,18 +553,18 @@ InnoDB
 ^^^^^^
 
 Make separate datasets for InnoDB's data files and log files. Set
-recordsize=16K on InnoDB's data files to avoid expensive partial record
+``recordsize=16K`` on InnoDB's data files to avoid expensive partial record
 writes and leave recordsize=128K on the log files. Set
-primarycache=metadata on both to prefer InnoDB's
-caching.\ `4 <https://www.patpro.net/blog/index.php/2014/03/09/2617-mysql-on-zfs-on-freebsd/>`__
-Set logbias=throughput on the data to stop ZIL from writing twice.
+``primarycache=metadata`` on both to prefer InnoDB's
+caching [#mysql_basic]_.
+Set ``logbias=throughput`` on the data to stop ZIL from writing twice.
 
-Set skip-innodb_doublewrite in my.cnf to prevent innodb from writing
+Set ``skip-innodb_doublewrite`` in my.cnf to prevent innodb from writing
 twice. The double writes are a data integrity feature meant to protect
 against corruption from partially-written records, but those are not
-possible on ZFS. It should be noted that Percona’s
-blog\ `5 <https://www.percona.com/blog/2014/05/23/improve-innodb-performance-write-bound-loads/>`__
-had advocated using an ext4 configuration where double writes were
+possible on ZFS. It should be noted that `Percona’s
+blog had advocated <https://www.percona.com/blog/2014/05/23/improve-innodb-performance-write-bound-loads/>`__
+using an ext4 configuration where double writes were
 turned off for a performance gain, but later recanted it because it
 caused data corruption. Following a well timed power failure, an in
 place filesystem such as ext4 can have half of a 8KB record be old while
@@ -578,15 +578,15 @@ off for better performance.
 
 On Linux, the driver's AIO implementation is a compatibility shim that
 just barely passes the POSIX standard. InnoDB performance suffers when
-using its default AIO codepath. Set innodb_use_native_aio=0 and
-innodb_use_atomic_writes=0 in my.cnf to disable AIO. Both of these
+using its default AIO codepath. Set ``innodb_use_native_aio=0`` and
+``innodb_use_atomic_writes=0`` in my.cnf to disable AIO. Both of these
 settings must be disabled to disable AIO.
 
 PostgreSQL
 ~~~~~~~~~~
 
-Make separate datasets for PostgreSQL's data and WAL. Set recordsize=8K
-on both to avoid expensive partial record writes. Set logbias=throughput
+Make separate datasets for PostgreSQL's data and WAL. Set ``recordsize=8K``
+on both to avoid expensive partial record writes. Set ``logbias=throughput``
 on PostgreSQL's data to avoid writing twice.
 
 SQLite
@@ -594,12 +594,12 @@ SQLite
 
 Make a separate dataset for the database. Set the recordsize to 64K. Set
 the SQLite page size to 65536
-bytes\ `6 <https://www.sqlite.org/pragma.html#pragma_page_size>`__.
+bytes [#sqlite_ps]_.
 
 Note that SQLite databases typically are not exercised enough to merit
 special tuning, but this will provide it. Note the side effect on cache
 size mentioned at
-SQLite.org\ `7 <https://www.sqlite.org/pgszchng2016.html>`__.
+SQLite.org [#sqlite_ps_change]_.
 
 .. _file_servers:
 
@@ -609,7 +609,7 @@ File servers
 Create a dedicated dataset for files being served.
 
 See
-`Performance_tuning#Sequential_workloads <Performance_tuning#Sequential_workloads>`__
+:ref:`Sequential workloads <sequential_workloads>`
 for configuration recommendations.
 
 .. _sequential_workloads:
@@ -619,12 +619,12 @@ Sequential workloads
 
 Set recordsize=1M on datasets that are subject to sequential workloads.
 Read
-`Performance_tuning#Larger_record_sizes <Performance_tuning#Larger_record_sizes>`__
+:ref:`Larger record sizes <larger_record_sizes>`
 for documentation on things that should be known before setting 1M
 record sizes.
 
-Set compression=lz4 as per the general recommendation for `LZ4
-compression <Performance_tuning#LZ4_compression>`__.
+Set compression=lz4 as per the general recommendation for :ref:`LZ4
+compression <lz4_compression>`.
 
 .. _video_games_directories:
 
@@ -637,7 +637,7 @@ the game download application to place games there. Specific information
 on how to configure various ones is below.
 
 See
-`Performance_tuning#Sequential_workloads <Performance_tuning#Sequential_workloads>`__
+:ref:`Sequential workloads <sequential_workloads>`
 for configuration recommendations before installing games.
 
 Note that the performance gains from this tuning are likely to be small
@@ -683,3 +683,10 @@ QEMU / KVM / Xen
 ~~~~~~~~~~~~~~~~
 
 AIO should be used to maximize IOPS when using files for guest storage.
+
+.. rubric:: Footnotes
+
+.. [#ssd_iops] <http://www.anandtech.com/show/6489/playing-with-op>
+.. [#mysql_basic] <https://www.patpro.net/blog/index.php/2014/03/09/2617-mysql-on-zfs-on-freebsd/>
+.. [#sqlite_ps] <https://www.sqlite.org/pragma.html#pragma_page_size>
+.. [#sqlite_ps_change] <https://www.sqlite.org/pgszchng2016.html>

--- a/docs/Performance and Tuning/Workload Tuning.rst
+++ b/docs/Performance and Tuning/Workload Tuning.rst
@@ -328,8 +328,7 @@ not changed and will remain as-is. Today, most vendors ship drives with
 write cache enabled by default.
 
 On Linux, the Linux IO elevator is largely redundant given that ZFS has
-its own IO elevator, so ZFS will set the IO elevator to noop to avoid
-unnecessary CPU overhead.
+its own IO elevator.
 
 ZFS will also create a GPT partition table own partitions when given a
 whole disk under illumos on x86/amd64 and on Linux. This is mainly to

--- a/docs/Project and Community/Mailing Lists.rst
+++ b/docs/Project and Community/Mailing Lists.rst
@@ -1,3 +1,5 @@
+.. _mailing_lists:
+
 Mailing Lists
 =============
 


### PR DESCRIPTION
Pandoc raw mediawiki->rst conversions are in separate commits for ease of review.

I'll add redirection in wiki after this PR merged.

We may want to move this pages because there are contributors ready to update them (there are some inconsistencies in Perf tuning page on wiki, for ex. with Postgresql case).