### PR TITLE
Include Debian security and update repos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Install Prerequisites
 The dependencies are available via pip::
 
    # For Debian based distros
-   sudo apt install pip3
+   sudo apt install python3-pip
    # For RPM-based distros
    sudo yum install python3-pip
 

--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -50,7 +50,7 @@ Contributing
 
 #. Install the tools::
 
-    sudo apt install pip3
+    sudo apt install python3-pip
     pip3 install -r docs/requirements.txt
     # Add ~/.local/bin to your $PATH, e.g. by adding this to ~/.bashrc:
     PATH=$HOME/.local/bin:$PATH

--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -553,6 +553,12 @@ Step 4: System Configuration
      deb http://deb.debian.org/debian buster main contrib
      deb-src http://deb.debian.org/debian buster main contrib
 
+     deb http://security.debian.org/debian-security buster/updates main contrib
+     deb-src http://security.debian.org/debian-security buster/updates main contrib
+
+     deb http://deb.debian.org/debian buster-updates main contrib
+     deb-src http://deb.debian.org/debian buster-updates main contrib
+
    ::
 
      vi /mnt/etc/apt/sources.list.d/buster-backports.list

--- a/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
@@ -471,6 +471,10 @@ Customize this file if the system is not a DHCP client.
   # vi /mnt/etc/apt/sources.list
   deb http://deb.debian.org/debian stretch main contrib
   deb-src http://deb.debian.org/debian stretch main contrib
+  deb http://security.debian.org/debian-security stretch/updates main contrib
+  deb-src http://security.debian.org/debian-security stretch/updates main contrib
+  deb http://deb.debian.org/debian stretch-updates main contrib
+  deb-src http://deb.debian.org/debian stretch-updates main contrib
 
   # vi /mnt/etc/apt/sources.list.d/stretch-backports.list
   deb http://deb.debian.org/debian stretch-backports main contrib

--- a/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
@@ -54,7 +54,7 @@ Contributing
 
 #. Install the tools::
 
-    sudo apt install pip3
+    sudo apt install python3-pip
     pip3 install -r docs/requirements.txt
     # Add ~/.local/bin to your $PATH, e.g. by adding this to ~/.bashrc:
     PATH=$HOME/.local/bin:$PATH

--- a/docs/Getting Started/Ubuntu/Ubuntu 16.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 16.04 Root on ZFS.rst
@@ -54,7 +54,7 @@ Contributing
 
 #. Install the tools::
 
-    sudo apt install pip3
+    sudo apt install python3-pip
     pip3 install -r docs/requirements.txt
     # Add ~/.local/bin to your $PATH, e.g. by adding this to ~/.bashrc:
     PATH=$HOME/.local/bin:$PATH

--- a/docs/Getting Started/Ubuntu/Ubuntu 18.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 18.04 Root on ZFS.rst
@@ -55,7 +55,7 @@ Contributing
 
 #. Install the tools::
 
-    sudo apt install pip3
+    sudo apt install python3-pip
     pip3 install -r docs/requirements.txt
     # Add ~/.local/bin to your $PATH, e.g. by adding this to ~/.bashrc:
     PATH=$HOME/.local/bin:$PATH

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
@@ -52,7 +52,7 @@ Contributing
 
 #. Install the tools::
 
-    sudo apt install pip3
+    sudo apt install python3-pip
     pip3 install -r docs/requirements.txt
     # Add ~/.local/bin to your $PATH, e.g. by adding this to ~/.bashrc:
     PATH=$HOME/.local/bin:$PATH

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
@@ -200,7 +200,7 @@ Contributing
 
 #. Install the tools::
 
-    sudo apt install pip3
+    sudo apt install python3-pip
     pip3 install -r docs/requirements.txt
     # Add ~/.local/bin to your $PATH, e.g. by adding this to ~/.bashrc:
     PATH=$HOME/.local/bin:$PATH


### PR DESCRIPTION
- The instructions for setting up a ZFS root on Debian systems do not configure the security or update repos. If the reader doesn't realize this, they will be missing important updates between minor releases.
- Also updated the pip3 install command to use the correct package name for all Debian/Ubuntu systems.