### PR TITLE
use apt instead of dpkg for os-prober removing

### DIFF
--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -650,7 +650,7 @@ Step 4: System Configuration
 
 #. Optional: Remove os-prober::
 
-     dpkg --purge os-prober
+     apt --purge os-prober
 
    This avoids error messages from `update-grub`.  `os-prober` is only
    necessary in dual-boot configurations.


### PR DESCRIPTION
Hi,

In general `apt` is the preferred way to interact with packages, and I think in this case there is no need/advantage to use `dpkg`.

Regards,
Yvan