### PR TITLE
Statically add ZOL 0.6.5.11 to the feature matrix

### DIFF
--- a/scripts/compatibility_matrix.py
+++ b/scripts/compatibility_matrix.py
@@ -32,6 +32,7 @@ def openzfs():
     with urlopen('https://zfsonlinux.org') as web:
         versions = findall(r'download/zfs-([0-9.]+)',
                            web.read().decode('utf-8', 'ignore'))
+    versions.append("0.6.5.11")
     for ver in set(versions):
         sources[ver] = ('https://raw.githubusercontent.com/openzfs/zfs/'
                         'zfs-{}/man/man5/zpool-features.5'.format(ver))


### PR DESCRIPTION
This resolves #83.  While 0.6.5.11 is old, it still had feature flags.
Since the 0.6.x branch will not receive further minor releases,
this static change should be stable.

Signed-off-by: Garrett Fields <ghfields@gmail.com>