### PR TITLE
Fixed GPG doc issue in Centos/RHEL 8

### DIFF
--- a/docs/Getting Started/Fedora.rst
+++ b/docs/Getting Started/Fedora.rst
@@ -35,10 +35,11 @@ the fingerprint listed here.
 .. code:: sh
 
    $ sudo dnf install https://zfsonlinux.org/fedora/zfs-release$(rpm -E %dist).noarch.rpm
-   $ gpg --quiet --with-fingerprint /etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux
-   pub  2048R/F14AB620 2013-03-21 ZFS on Linux <zfs@zfsonlinux.org>
-       Key fingerprint = C93A FFFD 9F3F 7B03 C310  CEB6 A9D5 A1C0 F14A B620
-       sub  2048R/99685629 2013-03-21
+   $ gpg --import --import-options show-only /etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux
+   pub   rsa2048 2013-03-21 [SC]
+         C93AFFFD9F3F7B03C310CEB6A9D5A1C0F14AB620
+   uid                      ZFS on Linux <zfs@zfsonlinux.org>
+   sub   rsa2048 2013-03-21 [E]
 
 The OpenZFS packages should be installed with ``dnf`` on Fedora.  Note that
 it is important to make sure that the matching *kernel-devel* package is

--- a/docs/Getting Started/RHEL and CentOS.rst
+++ b/docs/Getting Started/RHEL and CentOS.rst
@@ -42,10 +42,11 @@ And for RHEL/CentOS 8 and newer:
 .. code:: sh
 
    $ sudo dnf install https://zfsonlinux.org/epel/zfs-release.<dist>.noarch.rpm
-   $ gpg --quiet --with-fingerprint /etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux
-   pub  2048R/F14AB620 2013-03-21 ZFS on Linux <zfs@zfsonlinux.org>
-       Key fingerprint = C93A FFFD 9F3F 7B03 C310  CEB6 A9D5 A1C0 F14A B620
-       sub  2048R/99685629 2013-03-21
+   $ gpg --import --import-options show-only /etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux
+   pub   rsa2048 2013-03-21 [SC]
+         C93AFFFD9F3F7B03C310CEB6A9D5A1C0F14AB620
+   uid                      ZFS on Linux <zfs@zfsonlinux.org>
+   sub   rsa2048 2013-03-21 [E]
 
 After installing the *zfs-release* package and verifying the public key
 users can opt to install either the DKMS or kABI-tracking kmod style packages.


### PR DESCRIPTION
The documentation makes reference to using GPG to check the fingerprint of the zfs repository key. CentOS 8 is currently on gpg version 2.2.20, and the --with-fingerprint option appears to be deprecated, at least it does not output the example in the docs.

Verification info:

     $ cat /etc/centos-release
     CentOS Linux release 8.3.2011

     $ gpg --version
     gpg (GnuPG) 2.2.20
     libgcrypt 1.8.5
(abridged)
currently in documentation:

     $ gpg --quiet --with-fingerprint /etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux 
     pub   rsa2048 2013-03-21 [SC]
     uid           ZFS on Linux <zfs@zfsonlinux.org>
     sub   rsa2048 2013-03-21 [E]

proposed replacement:

     $ gpg --import --import-options show-only /etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux
     pub   rsa2048 2013-03-21 [SC]
           C93AFFFD9F3F7B03C310CEB6A9D5A1C0F14AB620
     uid                      ZFS on Linux <zfs@zfsonlinux.org>
     sub   rsa2048 2013-03-21 [E]



