### PR TITLE
Fix note formatting for incompatible kernel versions

### DIFF
--- a/docs/Getting Started/Arch Linux/Arch Linux Root on ZFS.rst
+++ b/docs/Getting Started/Arch Linux/Arch Linux Root on ZFS.rst
@@ -22,6 +22,16 @@ Caution
   will not work on 4Kn with legacy (BIOS) booting.
   <http://savannah.gnu.org/bugs/?46700>`__
 
+.. note::
+
+    Due to the release cycle of OpenZFS and the rapid adoption of new kernels
+    it may happen that you won’t be able to
+    build DKMS packages for the most recent kernel update.
+    If the `latest OpenZFS release <https://github.com/openzfs/zfs/releases/latest>`__
+    does not yet support the installed kernel,
+    `use an older live image <https://mirrors.dotsrc.org/archlinux/iso/>`__
+    before installation.
+
 Support
 ~~~~~~~
 
@@ -139,16 +149,6 @@ Prepare the Live Environment
 
    If this fails with ``unable to satisfy dependency``,
    install archzfs-dkms instead:
-
-   .. note::
-
-       Due to the release cycle of OpenZFS and the rapid adoption of new kernels
-       it may happen that you won’t be able to
-       build DKMS packages for the most recent kernel update.
-       If the `latest OpenZFS release <https://github.com/openzfs/zfs/releases/latest>`__
-       does not yet support the installed kernel,
-       `use an older live image <https://mirrors.dotsrc.org/archlinux/iso/>`__
-       before installation.
 
     #. Check the current kernel version with::
 

--- a/docs/Getting Started/Arch Linux/index.rst
+++ b/docs/Getting Started/Arch Linux/index.rst
@@ -12,6 +12,16 @@ Installation
 If you want to use ZFS as your root filesystem, see the `Root on ZFS`_
 links below instead.
 
+.. note::
+
+   Due to the release cycle of OpenZFS and the rapid adoption of new kernels
+   it may happen that you won’t be able to
+   build DKMS packages for the most recent kernel update.
+   If the `latest OpenZFS release <https://github.com/openzfs/zfs/releases/latest>`__
+   does not yet support the installed kernel,
+   `downgrade kernel <https://wiki.archlinux.org/index.php/downgrading_packages>`__
+   before installation.
+
 ZFS packages are provided by the third-party 
 `archzfs repository <https://github.com/archzfs/archzfs>`__.
 You can use it as follows.
@@ -52,16 +62,6 @@ Install packages.
 
 * If kernel dependency fails, or if you use a custom kernel,
   install zfs-dkms
-
-.. note::
-
-   Due to the release cycle of OpenZFS and the rapid adoption of new kernels
-   it may happen that you won’t be able to
-   build DKMS packages for the most recent kernel update.
-   If the `latest OpenZFS release <https://github.com/openzfs/zfs/releases/latest>`__
-   does not yet support the installed kernel,
-   `downgrade kernel <https://wiki.archlinux.org/index.php/downgrading_packages>`__
-   before installation.
 
   ::
 


### PR DESCRIPTION
Moved notes to the beginning of the articles. Previously the notes were placed in the instructions.

@gmelikov 