### PR TITLE
Arch Linux: Remove alternative solutions

### DIFF
--- a/docs/Getting Started/Arch Linux/Artix Linux Root on ZFS.rst
+++ b/docs/Getting Started/Arch Linux/Artix Linux Root on ZFS.rst
@@ -167,7 +167,7 @@ Prepare the Live Environment
      Uncomment and move mirrors to
      the beginning of the file.
 
-#. Install ZFS in the live environment::
+#. Install ZFS and tools in the live environment::
 
      pacman -Sy --noconfirm gdisk dosfstools archzfs-dkms
 
@@ -265,7 +265,7 @@ Format and Partition the Target Disks
    - If a separate swap partition is needed::
 
        sgdisk -n3:0:-8G -t3:BF00 $DISK
-       sgdisk -n4:0:0 -t4:8308 $DISK
+       sgdisk -n4:0:0   -t4:8308 $DISK
 
     Adjust the swap partition size to your needs.
 
@@ -290,7 +290,7 @@ Create Root and Boot Pools
     zpool create \
       ... \
       mirror \
-      /dev/disk/by-id/ata-disk1-part2
+      /dev/disk/by-id/ata-disk1-part2 \
       /dev/disk/by-id/ata-disk2-part2
 
    if needed, replace ``mirror`` with ``raidz1``, ``raidz2`` or ``raidz3``.
@@ -463,19 +463,6 @@ Create Datasets
      zfs create -o mountpoint=legacy -o canmount=noauto bpool_$INST_UUID/BOOT/default
      zfs create -o mountpoint=/      -o canmount=noauto rpool_$INST_UUID/ROOT/default
 
-   - ``canmount=noauto`` prevents ZFS from automatically
-     mounting datasets.
-
-   - Root dataset, specified with ``root=ZFS=rpool/ROOT/dataset`` at boot,
-     will be mounted regardless of other properties.
-
-   - Boot dataset is mounted with ``/etc/fstab``.
-     Its ``fstab`` entry will be updated upon the creation of
-     a new boot environment.
-
-   - ``zfs-mount-generator`` does not mount datasets
-     with ``canmount=noauto``.
-
 #. Mount root and boot filesystem datasets::
 
     zfs mount rpool_$INST_UUID/ROOT/default
@@ -558,10 +545,7 @@ Package Installation
 
    Check kernel version::
 
-     pacman -Syi ${INST_LINVAR} \
-     | grep 'Version' \
-     | awk '{ print $3 }'
-     # 5.10.1.artix1-1
+     INST_LINVER=$(pacman -Syi ${INST_LINVAR} | grep Version | awk '{ print $3 }')
 
    Check zfs-dkms package version::
 
@@ -580,7 +564,7 @@ Package Installation
 
    - Install archzfs-dkms::
 
-       basestrap $INST_MNT archzfs-dkms ${INST_LINVAR} ${INST_LINVAR}-headers
+       basestrap $INST_MNT zfs-dkms ${INST_LINVAR} ${INST_LINVAR}-headers
 
    If the kernel is not yet supported, install an older kernel:
 
@@ -593,15 +577,11 @@ Package Installation
 
    - Check kernel version::
 
-      curl https://archive.artixlinux.org/repos/${DKMS_DATE}/system/os/x86_64/ \
+      INST_LINVER=$(curl https://archive.artixlinux.org/repos/${DKMS_DATE}/core/os/x86_64/ \
       | grep \"${INST_LINVAR}-'[0-9]' \
-      | grep -v sig
-      # <a href="linux-5.10.3.arch1-1-x86_64.pkg.tar.zst">
-
-   - Set kernel version in a variable::
-
-      # <a href="linux-5.10.3.arch1-1-x86_64.pkg.tar.zst">
-      INST_LINVER=5.10.3.arch1-1
+      | grep -v sig \
+      | sed "s|.*$INST_LINVAR-||" \
+      | sed "s|-x86_64.*||")
 
    - Install kernel and headers::
 
@@ -611,7 +591,7 @@ Package Installation
 
    - Install archzfs-dkms::
 
-       basestrap $INST_MNT archzfs-dkms
+       basestrap $INST_MNT zfs-dkms
 
 #. Hold kernel package from updates::
 
@@ -772,43 +752,6 @@ A workaround is to replace the pool name detection with ``zdb``
 command::
 
  sed -i "s|rpool=.*|rpool=\`zdb -l \${GRUB_DEVICE} \| grep -E '[[:blank:]]name' \| cut -d\\\' -f 2\`|"  /etc/grub.d/10_linux
-
-**Notes:**
-
- In ``/etc/grub.d/10_linux``::
-
-   # rpool=`${grub_probe} --device ${GRUB_DEVICE} --target=fs_label 2>/dev/null || true`
-
- ``10_linux`` will return an empty result if the root pool has features
- not supported by GRUB.
-
- With this bug, the generated ``grub.cfg`` contains such lines::
-
-   root=ZFS=/ROOT/default # root pool name missing; unbootable
-
- Rendering the system unbootable.
-
- This will replace the faulty line in ``10_linux`` with::
-
-    # rpool=`zdb -l ${GRUB_DEVICE} | grep -E '[[:blank:]]name' | cut -d\' -f 2`
-
- Debian guide chose to hardcode ``root=ZFS=rpool/ROOT/default``
- in ``GRUB_CMDLINE_LINUX`` in ``/etc/default/grub``
- This is incompatible with the boot environment utility.
- The utility also uses this parameter to boot alternative
- root filesystem datasets.
-
- A boot environment entry::
-
-   # root=ZFS=rpool_UUID/ROOT/bootenv_after-sysupdate
-
- ``root=ZFS=pool/dataset`` is processed by
- the ZFS script in initramfs, used to
- tell the kernel the real root filesystem.
-
- ``zfs=bootfs`` kernel command line
- and ``zpool set bootfs=pool/dataset pool``
- is not used due to its inflexibility.
 
 GRUB Installation
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Signed-off-by: Maurice Zhou <ja@apvc.uk>

The previous approach to installation is: try this easy one first, and if it fails, try the hard one.
This commit streamlines the installation experience by minimizing references to such procedures.

This commit also removes verbose comments from Root on ZFS installation guides.

As the upstream has fixed glibc, its section is also removed.

@rlaager 