### PR TITLE
Update Ubuntu 20.04 Root on ZFS.rst

### DIFF
--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
@@ -893,19 +893,6 @@ Step 4: System Configuration
      addgroup --system lxd
      addgroup --system sambashare
 
-#. Patch a dependency loop:
-
-   For ZFS native encryption or LUKS::
-
-     sudo apt install --yes curl patch
-
-     curl https://launchpadlibrarian.net/478315221/2150-fix-systemd-dependency-loops.patch | \
-         sed "s|/etc|/lib|;s|\.in$||" | (cd / ; sudo patch -p1)
-
-   This patch is from `Bug #1875577 Encrypted swap won't load on 20.04 with
-   zfs root
-   <https://bugs.launchpad.net/ubuntu/+source/zfs-linux/+bug/1875577>`__.
-
 Step 5: GRUB Installation
 -------------------------
 


### PR DESCRIPTION
Hi, I'm not sure if this is correct or not - but this change removes section 4.15, "Patch a dependency loop", as it seems that this is no longer required now that https://github.com/openzfs/zfs/pull/10388 has been merged?

Following the current instructions in 4.15 generates the following console output:

```
root@rescue ~ # curl https://launchpadlibrarian.net/478315221/2150-fix-systemd-dependency-loops.patch | \
>     sed "s|/etc|/lib|;s|\.in$||" | (cd / ; sudo patch -p1)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1487  100  1487    0     0   4260      0 --:--:-- --:--:-- --:--:--  4260
patching file lib/systemd/system-generators/zfs-mount-generator
Hunk #1 FAILED at 42.
Hunk #2 FAILED at 62.
Hunk #3 succeeded at 157 with fuzz 2 (offset 80 lines).
2 out of 3 hunks FAILED -- saving rejects to file lib/systemd/system-generators/zfs-mount-generator.rej
patching file lib/systemd/system/zfs-mount.service
Hunk #1 FAILED at 6.
1 out of 1 hunk FAILED -- saving rejects to file lib/systemd/system/zfs-mount.service.rej
```

/lib/systemd/system/zfs-mount.service.rej contains the following:

```
root@rescue ~ # cat /lib/systemd/system-generators/zfs-mount-generator.rej
--- lib/systemd/system-generators/zfs-mount-generator
+++ lib/systemd/system-generators/zfs-mount-generator
@@ -42,6 +42,8 @@
   do_fail "zero or three arguments required"
 fi

+pools=$(zpool list -H -o name)
+
 # For ZFSs marked "auto", a dependency is created for local-fs.target. To
 # avoid regressions, this dependency is reduced to "wants" rather than
 # "requires". **THIS MAY CHANGE**
@@ -62,6 +64,7 @@
   set -f
   set -- $1
   dataset="${1}"
+  pool="${dataset%%/*}"
   p_mountpoint="${2}"
   p_canmount="${3}"
   p_atime="${4}"
```

/lib/systemd/system-generators/zfs-mount-generator seems to already contain equivalent code to the rejected hunks, and the accepted hunk seems to generate a code block starting line 160, that seems like a partial and older version of the code block at line 121?
```
121   # If the pool is already imported, zfs-import.target is not needed.  This
122   # avoids a dependency loop on root-on-ZFS systems:
123   # systemd-random-seed.service After (via RequiresMountsFor) var-lib.mount
124   # After zfs-import.target After zfs-import-{cache,scan}.service After
125   # cryptsetup.service After systemd-random-seed.service.
126   #
127   # Pools are newline-separated and may contain spaces in their names.
128   # There is no better portable way to set IFS to just a newline.  Using
129   # $(printf '\n') doesn't work because $(...) strips trailing newlines.
130   IFS="
131 "
132   for p in $pools ; do
133     if [ "$p" = "$pool" ] ; then
134       after=""
135       wants=""
136       break
137     fi
138   done
. . . . . 
160   # If the pool is already imported, zfs-import.target is not needed.  This
161   # avoids a dependency loop on root-on-ZFS systems:
162   # systemd-random-seed.service After (via RequiresMountsFor) var-lib.mount
163   # After zfs-import.target After zfs-import-{cache,scan}.service After
164   # cryptsetup.service After systemd-random-seed.service.
165   for p in $pools ; do
166     if [ "$p" = "$pool" ] ; then
167       wants=""
168       break
169     fi
170   done
```

/lib/systemd/system/zfs-mount.service.rej contains the following:
```
--- lib/systemd/system/zfs-mount.service
+++ lib/systemd/system/zfs-mount.service
@@ -6,7 +6,6 @@
 After=zfs-import.target
 After=systemd-remount-fs.service
 Before=local-fs.target
-Before=systemd-random-seed.service
 After=zfs-load-module.service
 ConditionPathExists=/sys/module/zfs
```
And /lib/systemd/system/zfs-mount.service does not contain the string "Before=systemd-random-seed.service"


...Is it therefore right to remove section 4.15 from this manual?