### PR TITLE
Arch Linux: Multiple fixes for Root on ZFS guides

### DIFF
--- a/docs/Getting Started/Arch Linux/Arch Linux Root on ZFS.rst
+++ b/docs/Getting Started/Arch Linux/Arch Linux Root on ZFS.rst
@@ -133,8 +133,13 @@ Prepare the Live Environment
 
 #. Add archzfs repository::
 
-    tee -a /etc/pacman.conf <<-'EOF'
+    tee -a /etc/pacman.conf <<- 'EOF'
+  
     [archzfs]
+    Include = /etc/pacman.d/mirrorlist-archzfs
+  
+    EOF
+    tee -a /etc/pacman.d/mirrorlist-archzfs <<- 'EOF'
     Server = https://archzfs.com/$repo/$arch
     Server = https://mirror.sum7.eu/archlinux/archzfs/$repo/$arch
     Server = https://mirror.biocrafting.net/archlinux/archzfs/$repo/$arch
@@ -149,16 +154,20 @@ Prepare the Live Environment
 
    - Edit the following files::
 
-       /etc/pacman.d/mirrorlist
+       nano /etc/pacman.d/mirrorlist
 
      Uncomment and move mirrors to
      the beginning of the file.
+
+   - Update database::
+
+       pacman -Sy
 
 #. Install ZFS in the live environment:
 
    Check kernel variant::
 
-    LIVE_LINVAR=$(sed 's|.*linux|linux|' /proc/cmdline | awk '{ print $1 }')
+    LIVE_LINVAR=$(sed 's|.*linux|linux|' /proc/cmdline | sed 's|.img||g' | awk '{ print $1 }')
 
    Check kernel version::
 
@@ -170,11 +179,11 @@ Prepare the Live Environment
 
    Expand root filesystem::
 
-    mount -o remount,size=1G /run/archiso/cowspace
+    mount -o remount,size=2G /run/archiso/cowspace
 
-   Install archzfs-dkms::
+   Install zfs-dkms::
 
-    pacman -S archzfs-dkms
+    pacman -S zfs-dkms glibc
 
 #. Load kernel module::
 
@@ -653,8 +662,13 @@ System Configuration
 
 #. archzfs repository::
 
-    tee -a $INST_MNT/etc/pacman.conf <<-'EOF'
+    tee -a $INST_MNT/etc/pacman.conf <<- 'EOF'
+
     [archzfs]
+    Include = /etc/pacman.d/mirrorlist-archzfs
+
+    EOF
+    tee -a $INST_MNT/etc/pacman.d/mirrorlist-archzfs <<- 'EOF'
     Server = https://archzfs.com/$repo/$arch
     Server = https://mirror.sum7.eu/archlinux/archzfs/$repo/$arch
     Server = https://mirror.biocrafting.net/archlinux/archzfs/$repo/$arch

--- a/docs/Getting Started/Arch Linux/index.rst
+++ b/docs/Getting Started/Arch Linux/index.rst
@@ -28,7 +28,12 @@ Import archzfs GPG key::
 Add the archzfs repository::
 
   tee -a /etc/pacman.conf <<- 'EOF'
+  
   [archzfs]
+  Include = /etc/pacman.d/mirrorlist-archzfs
+  
+  EOF
+  tee -a /etc/pacman.d/mirrorlist-archzfs <<- 'EOF'
   Server = https://archzfs.com/$repo/$arch
   Server = https://mirror.sum7.eu/archlinux/archzfs/$repo/$arch
   Server = https://mirror.biocrafting.net/archlinux/archzfs/$repo/$arch
@@ -51,7 +56,7 @@ For other kernels or distros, use `archzfs-dkms package`_.
 
 Check kernel variant::
 
- INST_LINVAR=$(sed 's|.*linux|linux|' /proc/cmdline | awk '{ print $1 }')
+ INST_LINVAR=$(sed 's|.*linux|linux|' /proc/cmdline | sed 's|.img||g' | awk '{ print $1 }')
 
 Check compatible kernel version::
 
@@ -77,7 +82,7 @@ Check kernel compatibility
 
 Check kernel variant::
 
- INST_LINVAR=$(sed 's|.*linux|linux|' /proc/cmdline | awk '{ print $1 }')
+ INST_LINVAR=$(sed 's|.*linux|linux|' /proc/cmdline | sed 's|.img||g' | awk '{ print $1 }')
 
 Check kernel version::
 


### PR DESCRIPTION
This commit includes multiple fixes for Arch/Artix Linux Root on ZFS guides.

- Separate archzfs repo mirrorlist from /etc/pacman.conf
- Include `nano` editor when editing text files
- Fix Linux package variant detection command
- Arch only: expand live root file system to 2GB
- Update glibc when installing zfs-dkms
- Artix-only: specify elogind-openrc
- Artix-only: fix repo name 'core' -> 'system'

Signed-off-by: Maurice Zhou <ja@apvc.uk>