### PR TITLE
Arch Linux: Nest system datasets; LUKS bpool; secure boot

### DIFF
--- a/docs/Getting Started/Arch Linux/index.rst
+++ b/docs/Getting Started/Arch Linux/index.rst
@@ -78,10 +78,15 @@ Check compatible kernel version::
 
  INST_LINVER=$(pacman -Si zfs-${INST_LINVAR} | grep 'Depends On' | sed "s|.*${INST_LINVAR}=||" | awk '{ print $1 }')
 
-Install compatible kernel::
+Install kernel. Download from archive if kernel is not available::
 
- pacman -U \
- https://archive.archlinux.org/packages/l/${INST_LINVAR}/${INST_LINVAR}-${INST_LINVER}-x86_64.pkg.tar.zst
+    if [ ${INST_LINVER} == \
+    $(pacman -Si ${INST_LINVAR} | grep Version | awk '{ print $3 }') ]; then
+     pacstrap $INST_MNT ${INST_LINVAR}
+    else
+     pacstrap -U $INST_MNT \
+     https://archive.archlinux.org/packages/l/${INST_LINVAR}/${INST_LINVAR}-${INST_LINVER}-x86_64.pkg.tar.zst
+    fi
 
 Install archzfs::
 


### PR DESCRIPTION
- Tell readers that encryption can not be enabled later pool-wide
- Add some warning messages for choosing a strong password
- Remove remains of default-key

@rlaager

Signed-off-by: Maurice Zhou <ja@apvc.uk>