### PR TITLE
Arch Linux: Use mountpoint=none for containers; hold zfs package from updates

### DIFF
--- a/docs/Getting Started/Arch Linux/index.rst
+++ b/docs/Getting Started/Arch Linux/index.rst
@@ -71,6 +71,7 @@ You can use it as follows.
 
     curl -L https://archzfs.com/archzfs.gpg |  pacman-key -a -
     curl -L https://git.io/JtQpl | xargs -i{} pacman-key --lsign-key {}
+    curl -L https://git.io/JtQp4 > /etc/pacman.d/mirrorlist-archzfs
 
 #. Add archzfs repository::
 
@@ -82,8 +83,6 @@ You can use it as follows.
     [archzfs]
     Include = /etc/pacman.d/mirrorlist-archzfs
     EOF
-
-    curl -L https://git.io/JtQp4 > /etc/pacman.d/mirrorlist-archzfs
 
 #. Update pacman database::
 
@@ -121,12 +120,15 @@ For other kernels or Arch-based distros, use zfs-dkms package.
 
     pacman -Sy zfs-${INST_LINVAR}
 
-#. Hold kernel package from updates::
+#. Ignore kernel updates::
 
      sed -i 's/#IgnorePkg/IgnorePkg/' /etc/pacman.conf
-     sed -i "/^IgnorePkg/ s/$/ ${INST_LINVAR} ${INST_LINVAR}-headers/" /etc/pacman.conf
+     sed -i "/^IgnorePkg/ s/$/ ${INST_LINVAR} ${INST_LINVAR}-headers zfs-${INST_LINVAR} zfs-utils/" /etc/pacman.conf
 
-   Kernel will be upgraded when an update for ``zfs-linux*`` becomes available.
+#. To update kernel, run::
+
+     INST_LINVAR=$(sed 's|.*linux|linux|' /proc/cmdline | sed 's|.img||g' | awk '{ print $1 }')
+     pacman -Sy --needed --noconfirm ${INST_LINVAR} ${INST_LINVAR}-headers zfs-${INST_LINVAR}
 
 zfs-dkms package
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
For proper boot environment support, system needs to be nested in container datasets, such as `rpool/ROOT`.
Currently the guide gives the following config:
```
NAME                       MOUNTPOINT  CANMOUNT
rpool                      /           off
rpool/sys                  /           off
rpool/sys/ROOT             none        off
rpool/sys/ROOT/default     /           noauto
```
This has caused [some confusion before](https://github.com/openzfs/openzfs-docs/issues/54#issuecomment-689811245) and is not necessary anyway.
This pull request attempts to clarify this issue by setting `-o canmount=off -o mountpoint=none` for container datasets.
```
NAME                       MOUNTPOINT  CANMOUNT
rpool                      none        off
rpool/sys                  none        off
rpool/sys/ROOT             none        off
rpool/sys/ROOT/default     /           noauto
```

This pull request also contains a fix for holding zfs packages from updates.

@rlaager 