### PR TITLE
Arch Linux: Remove zfs-utils from IgnorePkg; Reorganize page

### DIFF
--- a/docs/Getting Started/Arch Linux/Arch Linux Root on ZFS.rst
+++ b/docs/Getting Started/Arch Linux/Arch Linux Root on ZFS.rst
@@ -699,7 +699,7 @@ System Configuration
 #. Ignore kernel updates::
 
     sed -i 's/#IgnorePkg/IgnorePkg/' /etc/pacman.conf
-    sed -i "/^IgnorePkg/ s/$/ ${INST_LINVAR} ${INST_LINVAR}-headers zfs-${INST_LINVAR} zfs-utils/" /etc/pacman.conf
+    sed -i "/^IgnorePkg/ s/$/ ${INST_LINVAR} ${INST_LINVAR}-headers zfs-${INST_LINVAR}/" /etc/pacman.conf
 
    Kernel will be manually updated, see Getting Started.
 


### PR DESCRIPTION
This pull request removes `zfs-utils` from `IgnorePkg` list and reorganizes the index page.

@rlaager 

Signed-off-by: Maurice Zhou <ja@apvc.uk>