### PR TITLE
Remove duplicate creation of /mnt/run

### DIFF
--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -610,8 +610,6 @@ Step 4: System Configuration
      mount --rbind /dev  /mnt/dev
      mount --rbind /proc /mnt/proc
      mount --rbind /sys  /mnt/sys
-     mount -t tmpfs tmpfs /mnt/run
-     mkdir /mnt/run/lock
      chroot /mnt /usr/bin/env DISK=$DISK bash --login
 
    **Note:** This is using ``--rbind``, not ``--bind``.


### PR DESCRIPTION
Mounting `/mnt/run` and making `/mnt/run/lock` was already done above; no need to repeat it here.
@rlaager am I missing something?