### PR TITLE
Arch Linux: Add missing varable to chroot command; IgnorePkg fixes

### DIFF
--- a/docs/Getting Started/Arch Linux/Arch Linux Root on ZFS.rst
+++ b/docs/Getting Started/Arch Linux/Arch Linux Root on ZFS.rst
@@ -668,9 +668,9 @@ System Configuration
 
 #. Chroot::
 
-    for i in ${DISK[@]}; do printf "$i "; done
+    for i in ${DISK[@]}; do printf "$i "; done; printf '\n'
     # /dev/disk/by-id/disk1 /dev/disk/by-id/disk2
-    arch-chroot /mnt /usr/bin/env INST_UUID=$INST_UUID bash --login
+    arch-chroot /mnt /usr/bin/env INST_LINVAR=$INST_LINVAR INST_UUID=$INST_UUID bash --login
 
    Declare target disks::
 
@@ -699,7 +699,7 @@ System Configuration
 #. Ignore kernel updates::
 
     sed -i 's/#IgnorePkg/IgnorePkg/' /etc/pacman.conf
-    sed -i "/^IgnorePkg/ s/$/ ${INST_LINVAR} ${INST_LINVAR}-headers zfs-${INST_LINVAR}/" /etc/pacman.conf
+    sed -i "/^IgnorePkg/ s/$/ ${INST_LINVAR} ${INST_LINVAR}-headers zfs-${INST_LINVAR} zfs-utils/" /etc/pacman.conf
 
    Kernel will be manually updated, see Getting Started.
 

--- a/docs/Getting Started/Arch Linux/index.rst
+++ b/docs/Getting Started/Arch Linux/index.rst
@@ -130,12 +130,12 @@ For other kernels or Arch-based distros, use zfs-dkms package.
 #. Ignore kernel updates::
 
      sed -i 's/#IgnorePkg/IgnorePkg/' /etc/pacman.conf
-     sed -i "/^IgnorePkg/ s/$/ ${INST_LINVAR} ${INST_LINVAR}-headers zfs-${INST_LINVAR}/" /etc/pacman.conf
+     sed -i "/^IgnorePkg/ s/$/ ${INST_LINVAR} ${INST_LINVAR}-headers zfs-${INST_LINVAR} zfs-utils/" /etc/pacman.conf
 
 #. To update kernel, run::
 
      INST_LINVAR=$(sed 's|.*linux|linux|' /proc/cmdline | sed 's|.img||g' | awk '{ print $1 }')
-     pacman -Sy --needed --noconfirm ${INST_LINVAR} ${INST_LINVAR}-headers zfs-${INST_LINVAR}
+     pacman -Sy --needed --noconfirm ${INST_LINVAR} ${INST_LINVAR}-headers zfs-${INST_LINVAR} zfs-utils
 
 zfs-dkms package
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Oops, forgot to pass the kernel variant variable during chroot and more fixes for `IgnorePkg`.

@rlaager

Signed-off-by: Maurice Zhou <ja@apvc.uk>