### PR TITLE
Fix command to unmount ZFS filesystems

### DIFF
--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -866,7 +866,7 @@ Step 6: First Boot
 #. Run these commands in the LiveCD environment to unmount all
    filesystems::
 
-     mount | grep -v zfs | tac | awk '/\/mnt/ {print $3}' | \
+     mount | grep zfs | tac | awk '/\/mnt/ {print $3}' | \
          xargs -i{} umount -lf {}
      zpool export -a
 
@@ -1077,7 +1077,7 @@ Do whatever you need to do to fix your system.
 When done, cleanup::
 
   exit
-  mount | grep -v zfs | tac | awk '/\/mnt/ {print $3}' | \
+  mount | grep zfs | tac | awk '/\/mnt/ {print $3}' | \
       xargs -i{} umount -lf {}
   zpool export -a
   reboot

--- a/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
@@ -782,7 +782,7 @@ filesystems:
 
 ::
 
-  # mount | grep -v zfs | tac | awk '/\/mnt/ {print $3}' | xargs -i{} umount -lf {}
+  # mount | grep zfs | tac | awk '/\/mnt/ {print $3}' | xargs -i{} umount -lf {}
   # zpool export -a
 
 6.4 Reboot:
@@ -1015,7 +1015,7 @@ When done, cleanup:
 ::
 
   # exit
-  # mount | grep -v zfs | tac | awk '/\/mnt/ {print $3}' | xargs -i{} umount -lf {}
+  # mount | grep zfs | tac | awk '/\/mnt/ {print $3}' | xargs -i{} umount -lf {}
   # zpool export -a
   # reboot
 

--- a/docs/Getting Started/Ubuntu/Ubuntu 16.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 16.04 Root on ZFS.rst
@@ -633,7 +633,7 @@ filesystems:
 
 ::
 
-  # mount | grep -v zfs | tac | awk '/\/mnt/ {print $3}' | xargs -i{} umount -lf {}
+  # mount | grep zfs | tac | awk '/\/mnt/ {print $3}' | xargs -i{} umount -lf {}
   # zpool export rpool
 
 6.4 Reboot:
@@ -893,7 +893,7 @@ When done, cleanup:
 
 ::
 
-  # mount | grep -v zfs | tac | awk '/\/mnt/ {print $3}' | xargs -i{} umount -lf {}
+  # mount | grep zfs | tac | awk '/\/mnt/ {print $3}' | xargs -i{} umount -lf {}
   # zpool export rpool
   # reboot
 

--- a/docs/Getting Started/Ubuntu/Ubuntu 18.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 18.04 Root on ZFS.rst
@@ -738,7 +738,7 @@ save space.
 6.3 Run these commands in the LiveCD environment to unmount all
 filesystems::
 
-  mount | grep -v zfs | tac | awk '/\/mnt/ {print $3}' | xargs -i{} umount -lf {}
+  mount | grep zfs | tac | awk '/\/mnt/ {print $3}' | xargs -i{} umount -lf {}
   zpool export -a
 
 6.4 Reboot::
@@ -959,7 +959,7 @@ Do whatever you need to do to fix your system.
 When done, cleanup::
 
   exit
-  mount | grep -v zfs | tac | awk '/\/mnt/ {print $3}' | xargs -i{} umount -lf {}
+  mount | grep zfs | tac | awk '/\/mnt/ {print $3}' | xargs -i{} umount -lf {}
   zpool export -a
   reboot
 

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
@@ -1043,7 +1043,7 @@ Step 6: First Boot
 #. Run these commands in the LiveCD environment to unmount all
    filesystems::
 
-     mount | grep -v zfs | tac | awk '/\/mnt/ {print $3}' | \
+     mount | grep zfs | tac | awk '/\/mnt/ {print $3}' | \
          xargs -i{} umount -lf {}
      zpool export -a
 
@@ -1215,7 +1215,7 @@ Do whatever you need to do to fix your system.
 When done, cleanup::
 
   exit
-  mount | grep -v zfs | tac | awk '/\/mnt/ {print $3}' | \
+  mount | grep zfs | tac | awk '/\/mnt/ {print $3}' | \
       xargs -i{} umount -lf {}
   zpool export -a
   reboot

--- a/docs/Getting Started/openSUSE/openSUSE Leap Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Leap Root on ZFS.rst
@@ -973,7 +973,7 @@ Step 10: First Boot
 #. Run these commands in the LiveCD environment to unmount all
    filesystems::
 
-     mount | grep -v zfs | tac | awk '/\/mnt/ {print $3}' | \
+     mount | grep zfs | tac | awk '/\/mnt/ {print $3}' | \
          xargs -i{} umount -lf {}
      zpool export -a
 
@@ -1164,7 +1164,7 @@ Do whatever you need to do to fix your system.
 When done, cleanup::
 
   exit
-  mount | grep -v zfs | tac | awk '/\/mnt/ {print $3}' | \
+  mount | grep zfs | tac | awk '/\/mnt/ {print $3}' | \
       xargs -i{} umount -lf {}
   zpool export -a
   reboot

--- a/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
@@ -973,7 +973,7 @@ Step 10: First Boot
 #. Run these commands in the LiveCD environment to unmount all
    filesystems::
 
-     mount | grep -v zfs | tac | awk '/\/mnt/ {print $3}' | \
+     mount | grep zfs | tac | awk '/\/mnt/ {print $3}' | \
          xargs -i{} umount -lf {}
      zpool export -a
 
@@ -1164,7 +1164,7 @@ Do whatever you need to do to fix your system.
 When done, cleanup::
 
   exit
-  mount | grep -v zfs | tac | awk '/\/mnt/ {print $3}' | \
+  mount | grep zfs | tac | awk '/\/mnt/ {print $3}' | \
       xargs -i{} umount -lf {}
   zpool export -a
   reboot


### PR DESCRIPTION
Hi @rlaager 
I just followed the guide to install debian buster on ZFS root and noticed an error in the instructions that's present in all the instructions for Debian, Ubuntu, and openSUSE: the command to unmount ZFS filesystems was attempting to unmount all filesystems except the ZFS ones (grep -v). I believe the opposite should be done (grep without -v).

Signed-off-by: Marc Bevand <m.bevand@gmail.com>