### PR TITLE
Updated and corrected build instructions.

### DIFF
--- a/docs/Developer Resources/Building ZFS.rst
+++ b/docs/Developer Resources/Building ZFS.rst
@@ -16,7 +16,7 @@ There are two main components in this repository:
    vast majority of the core OpenZFS code is self-contained and can be
    used without modification.
 
-- **SPL**: The SPL is thin shim layer which is responsible for
+- **SPL**: The SPL is a thin shim layer which is responsible for
    implementing the fundamental interfaces required by OpenZFS. It's
    this layer which allows OpenZFS to be used across multiple
    platforms. SPL used to be maintained in a separate repository, but
@@ -28,31 +28,33 @@ Installing Dependencies
 
 The first thing you'll need to do is prepare your environment by
 installing a full development tool chain. In addition, development
-headers for both the kernel and the following libraries must be
+headers for both the kernel and the following packages must be
 available. It is important to note that if the development kernel
 headers for the currently running kernel aren't installed, the modules
 won't compile properly.
 
 The following dependencies should be installed to build the latest ZFS
-0.8 release.
+2.1 release.
 
 -  **RHEL/CentOS 7**:
 
 .. code:: sh
 
-   sudo yum install epel-release gcc make autoconf automake libtool rpm-build dkms libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel kernel-devel-$(uname -r) python python2-devel python-setuptools python-cffi libffi-devel git
+   sudo yum install epel-release gcc make autoconf automake libtool rpm-build libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel kernel-devel-$(uname -r) python python2-devel python-setuptools python-cffi libffi-devel git
+   sudo yum install --enablerepo=epel python-packaging dkms
 
 -  **RHEL/CentOS 8, Fedora**:
 
 .. code:: sh
 
-   sudo dnf install gcc make autoconf automake libtool rpm-build dkms libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel kernel-devel-$(uname -r) python3 python3-devel python3-setuptools python3-cffi libffi-devel git
+   sudo dnf install --skip-broken epel-release gcc make autoconf automake libtool rpm-build libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel kernel-devel-$(uname -r) python3 python3-devel python3-setuptools python3-cffi libffi-devel git
+   sudo dnf install --skip-broken --enablerepo=epel --enablerepo=powertools python3-packaging dkms
 
 -  **Debian, Ubuntu**:
 
 .. code:: sh
 
-   sudo apt install build-essential autoconf automake libtool gawk alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev libattr1-dev libelf-dev linux-headers-$(uname -r) python3 python3-dev python3-setuptools python3-cffi libffi-dev git
+   sudo apt install build-essential autoconf automake libtool gawk alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev libattr1-dev libelf-dev linux-headers-$(uname -r) python3 python3-dev python3-setuptools python3-cffi libffi-dev python3-packaging git
 
 Build Options
 ~~~~~~~~~~~~~
@@ -74,8 +76,8 @@ depends on your requirements.
 
 The remainder of this page focuses on the **in-tree** option which is
 the recommended method of development for the majority of changes. See
-the :doc:`custom packages <./Custom Packages>` page for additional information on building
-custom packages.
+the :doc:`custom packages <./Custom Packages>` page for additional
+information on building custom packages.
 
 Developing In-Tree
 ~~~~~~~~~~~~~~~~~~
@@ -108,7 +110,7 @@ the latest master branch.
 
 In this example we'll use the master branch and walk through a stock
 **in-tree** build. Start by checking out the desired branch then build
-the ZFS and SPL source in the tradition autotools fashion.
+the ZFS and SPL source in the traditional autotools fashion.
 
 ::
 
@@ -158,19 +160,28 @@ additional utilities must be installed.
 
 .. code:: sh
 
-   sudo yum install ksh bc fio acl sysstat mdadm lsscsi parted attr dbench nfs-utils samba rng-tools pax perf
+   sudo yum install ksh bc fio acl sysstat mdadm lsscsi parted attr nfs-utils samba rng-tools pax perf
+   sudo yum install --enablerepo=epel dbench
 
 -  **RHEL/CentOS 8, Fedora:**
 
 .. code:: sh
 
-   sudo dnf install ksh bc fio acl sysstat mdadm lsscsi parted attr dbench nfs-utils samba rng-tools pax perf
+   sudo dnf install --skip-broken ksh bc fio acl sysstat mdadm lsscsi parted attr nfs-utils samba rng-tools pax perf
+   sudo dnf install --skip-broken --enablerepo=epel dbench
 
--  **Debian, Ubuntu:**
+-  **Debian:**
+
+.. code:: sh
+
+   sudo apt install ksh bc fio acl sysstat mdadm lsscsi parted attr dbench nfs-kernel-server samba rng-tools pax linux-perf selinux-utils quota
+
+-  **Ubuntu:**
 
 .. code:: sh
 
    sudo apt install ksh bc fio acl sysstat mdadm lsscsi parted attr dbench nfs-kernel-server samba rng-tools pax linux-tools-common selinux-utils quota
+
 
 There are a few helper scripts provided in the top-level scripts
 directory designed to aid developers working with in-tree builds.
@@ -187,7 +198,7 @@ directory designed to aid developers working with in-tree builds.
    sudo ./scripts/zfs-helpers.sh -i
 
 -  **zfs.sh:** The freshly built kernel modules can be loaded using
-   ``zfs.sh``. This script can latter be used to unload the kernel
+   ``zfs.sh``. This script can later be used to unload the kernel
    modules with the **-u** option.
 
 ::

--- a/docs/Developer Resources/Custom Packages.rst
+++ b/docs/Developer Resources/Custom Packages.rst
@@ -61,19 +61,20 @@ RHEL, CentOS and Fedora
 -----------------------
 
 Make sure that the required packages are installed to build the latest
-ZFS 0.8 release:
+ZFS 2.1 release:
 
 -  **RHEL/CentOS 7**:
 
 .. code:: sh
 
-   sudo yum install epel-release gcc make autoconf automake libtool rpm-build dkms libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel kernel-devel-$(uname -r) python python2-devel python-setuptools python-cffi libffi-devel
+   sudo yum install epel-release gcc make autoconf automake libtool rpm-build libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel kernel-devel-$(uname -r) python python2-devel python-setuptools python-cffi libffi-devel
+   sudo yum install --enablerepo=epel dkms python-packaging
 
 -  **RHEL/CentOS 8, Fedora**:
 
 .. code:: sh
-
-   sudo dnf install gcc make autoconf automake libtool rpm-build kernel-rpm-macros dkms libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel kernel-devel-$(uname -r) python3 python3-devel python3-setuptools python3-cffi libffi-devel
+   sudo dnf install --skip-broken epel-release gcc make autoconf automake libtool rpm-build kernel-rpm-macros libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel kernel-devel-$(uname -r) python3 python3-devel python3-setuptools python3-cffi libffi-devel
+   sudo dnf install --skip-broken --enablerepo=epel --enablerepo=powertools python3-packaging dkms
 
 `Get the source code <#get-the-source-code>`__.
 
@@ -132,7 +133,7 @@ Make sure that the required packages are installed:
 
 .. code:: sh
 
-   sudo apt install build-essential autoconf automake libtool gawk alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev libattr1-dev libelf-dev linux-headers-$(uname -r) python3 python3-dev python3-setuptools python3-cffi libffi-dev
+   sudo apt install build-essential autoconf automake libtool gawk alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev libattr1-dev libelf-dev linux-headers-$(uname -r) python3 python3-dev python3-setuptools python3-cffi libffi-dev python3-packaging
 
 `Get the source code <#get-the-source-code>`__.
 


### PR DESCRIPTION
While adding python{,3}-packaging to the build requirements, I
suspected that the build instructions hadn't actually been tested
recently. So I checked, found problems, and corrected them.

Briefly:
* --skip-broken is needed in a number of commands to ignore the absence of EPEL/powertools on Fedora
* Broke out the install commands that specifically required EPEL/powertools; the alternative was breaking out the command to install EPEL, I have no strong opinion on which one to prefer.
* I had to break out the Debian/Ubuntu install step because Debian calls it linux-perf-KERNELVER with a linux-perf metapackage, while Ubuntu calls it linux-tools-common, neither has a compat package for the other's name, and apt appears to have no equivalent for --skip-broken to just specify both.
(The alternative of putting a shared Debian/Ubuntu command and then additional Debian/Ubuntu specific steps below it seemed to me to be likely to cause confusion; I can do that instead if people disagree.)
* EPEL is needed for python-packaging on EL7 (powertools, which ships disabled with the OS, is needed on CentOS8; I do not have an actual RHEL8 system to examine the state there)
* We still need --skip-broken for the command installing pax because it's (AFAICT) entirely absent on EL8

I've tested these instructions with:
* Ubuntu 21.04 x64
* Fedora 34 x64
* Debian 11 mips64el
* CentOS 8 x64
* CentOS 7 x64

And it successfully built {deb,rpm}-{kmod,dkms,utils} as appropriate (except on mips64el, but that seems to just be broken on the platform, not a problem of a missing dependency)

(If openzfs/zfs#12102 lands, I can instead drop the -packaging additions and rewrite the checks from openzfs/zfs#12073 that are the whole reason for adding the requirement...)