### PR TITLE
Move to libera.chat, freenode has been hijacked

### DIFF
--- a/docs/Getting Started/Arch Linux/index.rst
+++ b/docs/Getting Started/Arch Linux/index.rst
@@ -14,8 +14,8 @@ Contents
 Support
 -------
 Reach out to the community using the :ref:`mailing_lists` or IRC at
-`#zfsonlinux <irc://irc.freenode.net/#zfsonlinux>`__ on `freenode
-<https://freenode.net/>`__.
+`#zfsonlinux <ircs://irc.libera.chat/#zfsonlinux>`__ on `Libera Chat
+<https://libera.chat/>`__.
 
 If you have a bug report or feature request
 related to this HOWTO, please `file a new issue and mention @ne9z

--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -38,8 +38,8 @@ Support
 ~~~~~~~
 
 If you need help, reach out to the community using the :ref:`mailing_lists` or IRC at
-`#zfsonlinux <irc://irc.freenode.net/#zfsonlinux>`__ on `freenode
-<https://freenode.net/>`__. If you have a bug report or feature request
+`#zfsonlinux <ircs://irc.libera.chat/#zfsonlinux>`__ on `Libera Chat
+<https://libera.chat/>`__. If you have a bug report or feature request
 related to this HOWTO, please `file a new issue and mention @rlaager
 <https://github.com/openzfs/openzfs-docs/issues/new?body=@rlaager,%20I%20have%20the%20following%20issue%20with%20the%20Debian%20Buster%20Root%20on%20ZFS%20HOWTO:>`__.
 

--- a/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
@@ -42,8 +42,8 @@ Support
 ~~~~~~~
 
 If you need help, reach out to the community using the :ref:`mailing_lists` or IRC at
-`#zfsonlinux <irc://irc.freenode.net/#zfsonlinux>`__ on `freenode
-<https://freenode.net/>`__. If you have a bug report or feature request
+`#zfsonlinux <ircs://irc.libera.chat/#zfsonlinux>`__ on `Libera Chat
+<https://libera.chat/>`__. If you have a bug report or feature request
 related to this HOWTO, please `file a new issue and mention @rlaager
 <https://github.com/openzfs/openzfs-docs/issues/new?body=@rlaager,%20I%20have%20the%20following%20issue%20with%20the%20Debian%20Stretch%20Root%20on%20ZFS%20HOWTO:>`__.
 

--- a/docs/Getting Started/Ubuntu/Ubuntu 16.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 16.04 Root on ZFS.rst
@@ -42,8 +42,8 @@ Support
 ~~~~~~~
 
 If you need help, reach out to the community using the :ref:`mailing_lists` or IRC at
-`#zfsonlinux <irc://irc.freenode.net/#zfsonlinux>`__ on `freenode
-<https://freenode.net/>`__. If you have a bug report or feature request
+`#zfsonlinux <ircs://irc.libera.chat/#zfsonlinux>`__ on `Libera Chat
+<https://libera.chat/>`__. If you have a bug report or feature request
 related to this HOWTO, please `file a new issue and mention @rlaager
 <https://github.com/openzfs/openzfs-docs/issues/new?body=@rlaager,%20I%20have%20the%20following%20issue%20with%20the%20Ubuntu%2016.04%20Root%20on%20ZFS%20HOWTO:>`__.
 

--- a/docs/Getting Started/Ubuntu/Ubuntu 18.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 18.04 Root on ZFS.rst
@@ -43,8 +43,8 @@ Support
 ~~~~~~~
 
 If you need help, reach out to the community using the :ref:`mailing_lists` or IRC at
-`#zfsonlinux <irc://irc.freenode.net/#zfsonlinux>`__ on `freenode
-<https://freenode.net/>`__. If you have a bug report or feature request
+`#zfsonlinux <ircs://irc.libera.chat/#zfsonlinux>`__ on `Libera Chat
+<https://libera.chat/>`__. If you have a bug report or feature request
 related to this HOWTO, please `file a new issue and mention @rlaager
 <https://github.com/openzfs/openzfs-docs/issues/new?body=@rlaager,%20I%20have%20the%20following%20issue%20with%20the%20Ubuntu%2018.04%20Root%20on%20ZFS%20HOWTO:>`__.
 

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
@@ -40,8 +40,8 @@ Support
 ~~~~~~~
 
 If you need help, reach out to the community using the :ref:`mailing_lists` or IRC at
-`#zfsonlinux <irc://irc.freenode.net/#zfsonlinux>`__ on `freenode
-<https://freenode.net/>`__. If you have a bug report or feature request
+`#zfsonlinux <ircs://irc.libera.chat/#zfsonlinux>`__ on `Libera Chat
+<https://libera.chat/>`__. If you have a bug report or feature request
 related to this HOWTO, please `file a new issue and mention @rlaager
 <https://github.com/openzfs/openzfs-docs/issues/new?body=@rlaager,%20I%20have%20the%20following%20issue%20with%20the%20Ubuntu%2020.04%20Root%20on%20ZFS%20for%20Raspberry%20Pi%20HOWTO:>`__.
 

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
@@ -170,8 +170,8 @@ Support
 ~~~~~~~
 
 If you need help, reach out to the community using the :ref:`mailing_lists` or IRC at
-`#zfsonlinux <irc://irc.freenode.net/#zfsonlinux>`__ on `freenode
-<https://freenode.net/>`__. If you have a bug report or feature request
+`#zfsonlinux <ircs://irc.libera.chat/#zfsonlinux>`__ on `Libera Chat
+<https://libera.chat/>`__. If you have a bug report or feature request
 related to this HOWTO, please `file a new issue and mention @rlaager
 <https://github.com/openzfs/openzfs-docs/issues/new?body=@rlaager,%20I%20have%20the%20following%20issue%20with%20the%20Ubuntu%2020.04%20Root%20on%20ZFS%20HOWTO:>`__.
 

--- a/docs/Getting Started/openSUSE/openSUSE Leap Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Leap Root on ZFS.rst
@@ -46,8 +46,8 @@ Support
 ~~~~~~~
 
 If you need help, reach out to the community using the :ref:`mailing_lists` or IRC at
-`#zfsonlinux <irc://irc.freenode.net/#zfsonlinux>`__ on `freenode
-<https://freenode.net/>`__. If you have a bug report or feature request
+`#zfsonlinux <ircs://irc.libera.chat/#zfsonlinux>`__ on `Libera Chat
+<https://libera.chat/>`__. If you have a bug report or feature request
 related to this HOWTO, please file a new issue and mention `@Zaryob <https://github.com/Zaryob>`__.
 
 Contributing

--- a/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
@@ -45,8 +45,8 @@ Support
 ~~~~~~~
 
 If you need help, reach out to the community using the :ref:`mailing_lists` or IRC at
-`#zfsonlinux <irc://irc.freenode.net/#zfsonlinux>`__ on `freenode
-<https://freenode.net/>`__. If you have a bug report or feature request
+`#zfsonlinux <ircs://irc.libera.chat/#zfsonlinux>`__ on `Libera Chat
+<https://libera.chat/>`__. If you have a bug report or feature request
 related to this HOWTO, please file a new issue and mention `@Zaryob <https://github.com/Zaryob>`__.
 
 Contributing


### PR DESCRIPTION
In the light of recent upheaval, it is high time to replace all refs to freenode with libera.chat.

Relevant discussions:
- https://news.ycombinator.com/item?id=27287750
- https://news.ycombinator.com/item?id=27289071

We need to register OpenZFS project at libera.chat first: [project registration](https://libera.chat/chanreg#project-registration)
@rlaager @gmelikov 

Signed-off-by: Maurice Zhou <ja@apvc.uk>