### PR TITLE
GRUB menu need to be regenerated after kernel update

### DIFF
--- a/docs/Getting Started/Fedora/Root on ZFS/0-overview.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/0-overview.rst
@@ -109,4 +109,4 @@ Encryption
   can be verified by motherboard firmware to be untempered,
   which should be sufficient for most purposes.
 
-  Secure Boot is supported out-of-the-box by Fedora.
+  Secure Boot is not supported out-of-the-box due to ZFS module.

--- a/docs/Getting Started/Fedora/Root on ZFS/5-bootloader.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/5-bootloader.rst
@@ -103,14 +103,18 @@ Install GRUB
    To support Secure Boot, GRUB has been heavily modified by Fedora,
    namely:
 
-    - ``grub2-install`` is `disabled for UEFI <https://bugzilla.redhat.com/show_bug.cgi?id=1917213>`__
-    - Only a static, signed version of bootloader is copied to EFI system partition
-    - This signed bootloader does not have built-in support for either ZFS or LUKS containers
-    - This signed bootloader only loads configuration from ``/boot/efi/EFI/fedora/grub.cfg``
+   - ``grub2-install`` is `disabled for UEFI <https://bugzilla.redhat.com/show_bug.cgi?id=1917213>`__
+   - Only a static, signed version of bootloader is copied to EFI system partition
+   - This signed bootloader does not have built-in support for either ZFS or LUKS containers
+   - This signed bootloader only loads configuration from ``/boot/efi/EFI/fedora/grub.cfg``
 
    Unrelated to Secure Boot, GRUB has also been modified to provide optional
    support for `systemd bootloader specification (bls) <https://systemd.io/BOOT_LOADER_SPECIFICATION/>`__.
    Currently ``blscfg.mod`` is incompatible with root on ZFS.
+
+   As bls is disabled, you will need to regenerate GRUB menu after each kernel upgrade.
+   Or else the new kernel will not be recognized and system will boot the old kernel
+   on reboot.
 
    Also see `Fedora docs for GRUB
    <https://docs.fedoraproject.org/en-US/fedora/rawhide/system-administrators-guide/kernel-module-driver-configuration/Working_with_the_GRUB_2_Boot_Loader/>`__.

--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS.rst
@@ -1,6 +1,6 @@
 RHEL 8-based distro Root on ZFS
 =======================================
-`Start here <Root%20on%20ZFS/0-overview.html>`__.
+`Start here <RHEL%208-based%20distro%20Root%20on%20ZFS/0-overview.html>`__.
 
 Contents
 --------

--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/0-overview.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/0-overview.rst
@@ -109,4 +109,4 @@ Encryption
   can be verified by motherboard firmware to be untempered,
   which should be sufficient for most purposes.
 
-  Secure Boot is supported out-of-the-box by RHEL 8-based distro.
+  Secure Boot is not supported out-of-the-box due to ZFS module.

--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/5-bootloader.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/5-bootloader.rst
@@ -114,14 +114,18 @@ Install GRUB
    To support Secure Boot, GRUB has been heavily modified by Fedora,
    namely:
 
-    - ``grub2-install`` is `disabled for UEFI <https://bugzilla.redhat.com/show_bug.cgi?id=1917213>`__
-    - Only a static, signed version of bootloader is copied to EFI system partition
-    - This signed bootloader does not have built-in support for either ZFS or LUKS containers
-    - This signed bootloader only loads configuration from ``/boot/efi/EFI/fedora/grub.cfg``
+   - ``grub2-install`` is `disabled for UEFI <https://bugzilla.redhat.com/show_bug.cgi?id=1917213>`__
+   - Only a static, signed version of bootloader is copied to EFI system partition
+   - This signed bootloader does not have built-in support for either ZFS or LUKS containers
+   - This signed bootloader only loads configuration from ``/boot/efi/EFI/fedora/grub.cfg``
 
    Unrelated to Secure Boot, GRUB has also been modified to provide optional
    support for `systemd bootloader specification (bls) <https://systemd.io/BOOT_LOADER_SPECIFICATION/>`__.
    Currently ``blscfg.mod`` is incompatible with root on ZFS.
+
+   As bls is disabled, you will need to regenerate GRUB menu after each kernel upgrade.
+   Or else the new kernel will not be recognized and system will boot the old kernel
+   on reboot.
 
    Also see `Fedora docs for GRUB
    <https://docs.fedoraproject.org/en-US/fedora/rawhide/system-administrators-guide/kernel-module-driver-configuration/Working_with_the_GRUB_2_Boot_Loader/>`__.


### PR DESCRIPTION
@gmelikov Thanks for the merge! I'm deeply grateful for your trust to merge the guides and put them into public view.

I've been running Fedora on ZFS on my two laptops and RockyLinux on my home server for 2 months now, the only issue I encountered so far is the need to regenerate GRUB menu after each kernel update.

I've included this instruction in this PR. 

Signed-off-by: Maurice Zhou <jasper@apvc.uk>

Closes some solved issues.

closes #173 
closes #172