### PR TITLE
Fixes for Fedora; support Rocky Linux Live ISO

### DIFF
--- a/docs/Getting Started/Arch Linux/Root on ZFS/1-preparation.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS/1-preparation.rst
@@ -104,6 +104,24 @@ Preparation
 
     INST_VDEV=
 
+   This will create a single vdev with the topology of your choice.
+   It is also possible to manually create a pool with multiple vdevs, such as::
+
+    zpool create --options \
+          poolName \
+          mirror sda sdb \
+          raidz2 sdc ... \
+          raidz3 sde ... \
+          spare  sdf ...
+
+   Notice the cost of parity when using RAID-Z. See
+   `here <https://www.delphix.com/blog/delphix-engineering/zfs-raidz-stripe-width-or-how-i-learned-stop-worrying-and-love-raidz>`__
+   and `here <https://docs.google.com/spreadsheets/d/1tf4qx1aMJp8Lo_R6gpT689wTjHv6CGVElrPqTA0w_ZY/>`__.
+
+   Refer to `zpoolconcepts <https://openzfs.github.io/openzfs-docs/man/7/zpoolconcepts.7.html>`__
+   and `zpool-create <https://openzfs.github.io/openzfs-docs/man/8/zpool-create.8.html>`__
+   man pages for details.
+
 #. Set partition size:
 
    Set ESP size. ESP contains Live ISO for recovery,

--- a/docs/Getting Started/Arch Linux/Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS/3-system-configuration.rst
@@ -92,6 +92,10 @@ System Configuration
 
     arch-chroot /mnt passwd
 
+#. Generate host id::
+
+    zgenhostid -f -o /mnt/etc/hostid
+
 #. Ignore kernel updates::
 
     sed -i 's/#IgnorePkg/IgnorePkg/' /mnt/etc/pacman.conf

--- a/docs/Getting Started/Arch Linux/Root on ZFS/5-bootloader.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS/5-bootloader.rst
@@ -50,9 +50,6 @@ Install GRUB
 
     mkinitcpio -P
 
-#. When in doubt, install both legacy boot
-   and EFI.
-
 #. Create GRUB boot directory, in ESP and boot pool::
 
     mkdir -p /boot/efi/EFI/arch
@@ -60,6 +57,9 @@ Install GRUB
 
    Boot environment-specific configuration (kernel, etc)
    is stored in ``/boot/grub/grub.cfg``, enabling rollback.
+
+#. When in doubt, install both legacy boot
+   and EFI.
 
 #. If using legacy booting, install GRUB to every disk::
 

--- a/docs/Getting Started/Fedora/Root on ZFS/1-preparation.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/1-preparation.rst
@@ -43,7 +43,7 @@ Preparation
 
 #. Install helper script and partition tool::
 
-    dnf install -y arch-install-scripts gdisk
+    dnf install -y arch-install-scripts gdisk dosfstools
 
 #. Target Fedora version::
 
@@ -93,6 +93,24 @@ Preparation
    ::
 
     INST_VDEV=
+
+   This will create a single vdev with the topology of your choice.
+   It is also possible to manually create a pool with multiple vdevs, such as::
+
+    zpool create --options \
+          poolName \
+          mirror sda sdb \
+          raidz2 sdc ... \
+          raidz3 sde ... \
+          spare  sdf ...
+
+   Notice the cost of parity when using RAID-Z. See
+   `here <https://www.delphix.com/blog/delphix-engineering/zfs-raidz-stripe-width-or-how-i-learned-stop-worrying-and-love-raidz>`__
+   and `here <https://docs.google.com/spreadsheets/d/1tf4qx1aMJp8Lo_R6gpT689wTjHv6CGVElrPqTA0w_ZY/>`__.
+
+   Refer to `zpoolconcepts <https://openzfs.github.io/openzfs-docs/man/7/zpoolconcepts.7.html>`__
+   and `zpool-create <https://openzfs.github.io/openzfs-docs/man/8/zpool-create.8.html>`__
+   man pages for details.
 
 #. Set partition size:
 

--- a/docs/Getting Started/Fedora/Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/3-system-configuration.rst
@@ -81,6 +81,10 @@ System Configuration
 
    ``systemd-firstboot`` have bugs, root password is set below.
 
+#. Generate host id::
+
+    zgenhostid -f -o /mnt/etc/hostid
+
 #. Install locale package, example for English locale::
 
     dnf --installroot=/mnt install -y glibc-minimal-langpack glibc-langpack-en
@@ -95,6 +99,7 @@ System Configuration
    disable SSH server::
 
     systemctl disable sshd --root=/mnt
+    systemctl enable firewalld --root=/mnt
 
 #. Chroot::
 
@@ -102,16 +107,16 @@ System Configuration
     INST_LINVAR=$INST_LINVAR
     INST_UUID=$INST_UUID
     INST_ID=$INST_ID
+    unalias -a
     INST_VDEV=$INST_VDEV" > /mnt/root/chroot
     echo DISK=\($(for i in ${DISK[@]}; do printf "$i "; done)\) >> /mnt/root/chroot
     arch-chroot /mnt bash --login
-    unalias -a
 
 #. Source variables::
 
     source /root/chroot
 
-#. Relabel filesystem on next boot::
+#. For SELinux, relabel filesystem on next boot::
 
     fixfiles -F onboot
 

--- a/docs/Getting Started/Fedora/Root on ZFS/5-bootloader.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/5-bootloader.rst
@@ -54,9 +54,6 @@ Install GRUB
       dracut --force --kver $kernel_version
       done
 
-#. When in doubt, install both legacy boot
-   and EFI.
-
 #. Disable BLS::
 
     echo "GRUB_ENABLE_BLSCFG=false" >> /etc/default/grub
@@ -69,6 +66,9 @@ Install GRUB
 
    Boot environment-specific configuration (kernel, etc)
    is stored in ``/boot/grub2/grub.cfg``, enabling rollback.
+
+#. When in doubt, install both legacy boot
+   and EFI.
 
 #. If using legacy booting, install GRUB to every disk::
 
@@ -93,6 +93,7 @@ Install GRUB
 #. For both legacy and EFI booting: mirror ESP content::
 
     ESP_MIRROR=$(mktemp -d)
+    unalias -a
     cp -r /boot/efi/EFI $ESP_MIRROR
     for i in /boot/efis/*; do
      cp -r $ESP_MIRROR/EFI $i

--- a/docs/Getting Started/Fedora/Root on ZFS/6-recovery.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/6-recovery.rst
@@ -187,21 +187,21 @@ it is relatively easy to perform a system backup and migration.
 
 #. Create a snapshot of root file system::
 
-    zfs snapshot -r rpool/arch@backup
-    zfs snapshot -r bpool/arch@backup
+    zfs snapshot -r rpool/$INST_ID@backup
+    zfs snapshot -r bpool/$INST_ID@backup
 
 #. Save snapshot to a file or pipe to SSH::
 
-    zfs send --options rpool/arch@backup > /backup/arch-rpool
-    zfs send --options bpool/arch@backup > /backup/arch-bpool
+    zfs send --options rpool/$INST_ID@backup > /backup/$INST_ID-rpool
+    zfs send --options bpool/$INST_ID@backup > /backup/$INST_ID-bpool
 
 #. Re-create partitions and root/boot
    pool on target system.
 
 #. Restore backup::
 
-    zfs recv rpool_new/arch < /backup/arch-rpool
-    zfs recv bpool_new/arch < /backup/arch-bpool
+    zfs recv rpool_new/$INST_ID < /backup/$INST_ID-rpool
+    zfs recv bpool_new/$INST_ID < /backup/$INST_ID-bpool
 
 #. Chroot and reinstall bootloader.
 

--- a/docs/Getting Started/Fedora/Root on ZFS/6-recovery.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/6-recovery.rst
@@ -21,13 +21,14 @@ This section is also applicable if you are in
 #. On another computer, generate rescue image with::
 
      pacman -S --needed mtools libisoburn grub
+     grub-install
      grub-mkrescue -o grub-rescue.img
      dd if=grub-rescue.img of=/dev/your-usb-stick
 
    Boot computer from the rescue media.
    Both legacy and EFI mode are supported.
 
-   Skip this step if you are in GRUB rescue.
+   Or `download generated GRUB rescue image <https://gitlab.com/m_zhou/bieaz/uploads/4a1b7cefb42723de6eb04f9dc485be3b/grub-rescue.img.7z>`__.
 
 #. List available disks with ``ls`` command::
 
@@ -35,20 +36,6 @@ This section is also applicable if you are in
     Possible devices are:
 
      hd0 hd1 hd2 hd3
-
-   If you are dropped to GRUB rescue instead of
-   booting from GRUB rescue image, boot disk can be found
-   out with::
-
-    echo $root
-    # cryto0
-    # hd0,gpt2
-
-   GRUB configuration is loaded from::
-
-    echo $prefix
-    # (crypto0)/sys/BOOT/default@/grub
-    # (hd0,gpt2)/sys/BOOT/default@/grub
 
 #. List partitions by pressing tab key:
 
@@ -94,12 +81,10 @@ This section is also applicable if you are in
      grub> ls (crypto0)/sys/BOOT
      @/ default/ be0/
 
-#. Instruct GRUB to load configuration from ``be0`` boot environment
-   then enter normal mode::
+#. Instruct GRUB to load configuration from ``be0`` boot environment::
 
      grub> prefix=(crypto0)/sys/BOOT/be0/@/grub
-     grub> insmod normal
-     grub> normal
+     grub> configfile $prefix/grub.cfg
 
 #. GRUB menu should now appear.
 
@@ -188,7 +173,7 @@ Access system in chroot
 
 #. chroot into the system::
 
-     fedora-chroot /mnt /bin/bash --login
+     arch-chroot /mnt /bin/bash --login
      zfs mount -a
      mount -a
 
@@ -202,21 +187,21 @@ it is relatively easy to perform a system backup and migration.
 
 #. Create a snapshot of root file system::
 
-    zfs snapshot -r rpool/fedora@backup
-    zfs snapshot -r bpool/fedora@backup
+    zfs snapshot -r rpool/arch@backup
+    zfs snapshot -r bpool/arch@backup
 
 #. Save snapshot to a file or pipe to SSH::
 
-    zfs send --options rpool/fedora@backup > /backup/fedora-rpool
-    zfs send --options bpool/fedora@backup > /backup/fedora-bpool
+    zfs send --options rpool/arch@backup > /backup/arch-rpool
+    zfs send --options bpool/arch@backup > /backup/arch-bpool
 
 #. Re-create partitions and root/boot
    pool on target system.
 
 #. Restore backup::
 
-    zfs recv rpool_new/fedora < /backup/fedora-rpool
-    zfs recv bpool_new/fedora < /backup/fedora-bpool
+    zfs recv rpool_new/arch < /backup/arch-rpool
+    zfs recv bpool_new/arch < /backup/arch-bpool
 
 #. Chroot and reinstall bootloader.
 

--- a/docs/Getting Started/Fedora/index.rst
+++ b/docs/Getting Started/Fedora/index.rst
@@ -34,8 +34,17 @@ see below.
 
     dnf copr enable -y kwizart/kernel-longterm-5.4
     dnf install -y kernel-longterm kernel-longterm-devel
-    # reboot to new LTS kernel
+
+   Reboot to new LTS kernel, then load kernel module::
+
     modprobe zfs
+
+   It might be necessary to rebuild module::
+
+    ls -1 /lib/modules \
+    | while read kernel_version; do
+      dkms autoinstall -k $kernel_version
+    done
 
 #. By default ZFS kernel modules are loaded upon detecting a pool.
    To always load the modules at boot::

--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS.rst
@@ -1,4 +1,4 @@
-RHEL 8-based distro Root on ZFS
+Rocky Linux 8 Root on ZFS
 =======================================
 `Start here <RHEL%208-based%20distro%20Root%20on%20ZFS/0-overview.html>`__.
 

--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/2-system-installation.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/2-system-installation.rst
@@ -70,25 +70,12 @@ System Installation
 #. Create root pool::
 
        zpool create \
-           -d \
-           -o feature@empty_bpobj=enabled \
-           -o feature@lz4_compress=enabled \
-           -o feature@spacemap_histogram=enabled \
-           -o feature@enabled_txg=enabled \
-           -o feature@hole_birth=enabled \
-           -o feature@extensible_dataset=enabled \
-           -o feature@embedded_data=enabled \
-           -o feature@large_dnode=enabled \
-           -o feature@userobj_accounting=enabled \
-           -o feature@encryption=enabled \
-           -o feature@project_quota=enabled \
-           -o feature@spacemap_v2=enabled \
            -o ashift=12 \
            -o autotrim=on \
            -R /mnt \
            -O acltype=posixacl \
            -O canmount=off \
-           -O compression=lz4 \
+           -O compression=zstd \
            -O dnodesize=auto \
            -O normalization=formD \
            -O relatime=on \
@@ -232,15 +219,16 @@ System Installation
 
 #. Install base packages::
 
-    dnf --installroot=/mnt --releasever=${INST_RHEL_VER} -y install dnf
+    dnf --installroot=/mnt --releasever=${INST_RHEL_VER} -y install \
+    ${RHEL_ZFS_REPO} @core epel-release grub2-efi-x64 grub2-pc-modules grub2-efi-x64-modules shim-x64 efibootmgr
+    dnf config-manager --installroot=/mnt --disable zfs
+    dnf config-manager --installroot=/mnt --enable zfs-kmod
+    dnf install --installroot=/mnt -y zfs zfs-dracut
 
-#. Install bootloader, kernel and ZFS::
+   If speed is slow, you can manually pick a fixed mirror
+   from `mirrorlist <https://mirrors.rockylinux.org/mirrormanager/mirrors>`__
+   and apply it::
 
-    cp /etc/resolv.conf /mnt/etc
-    arch-chroot /mnt bash --login <<EOF
-    dnf --releasever=${INST_RHEL_VER} -y install ${RHEL_ZFS_REPO} \
-    @core epel-release \
-    grub2-efi-x64 grub2-pc-modules grub2-efi-x64-modules shim-x64 efibootmgr \
-    kernel kernel-devel
-    dnf --releasever=${INST_RHEL_VER} -y install zfs zfs-dracut
-    EOF
+    sed -i 's|^mirrorlist=|#mirrorlist=|g' /etc/yum.repos.d/*
+    sed -i 's|^#baseurl=|baseurl=|g' /etc/yum.repos.d/*
+    sed -i 's|dl.rockylinux.org/$contentdir|mirrors.sjtug.sjtu.edu.cn/rocky|g' /etc/yum.repos.d/*

--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/5-bootloader.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/5-bootloader.rst
@@ -54,9 +54,6 @@ Install GRUB
       dracut --force --kver $kernel_version
       done
 
-#. When in doubt, install both legacy boot
-   and EFI.
-
 #. Load ZFS modules and disable BLS::
 
     echo 'GRUB_ENABLE_BLSCFG=false' >> /etc/default/grub
@@ -69,6 +66,9 @@ Install GRUB
 
    Boot environment-specific configuration (kernel, etc)
    is stored in ``/boot/grub2/grub.cfg``, enabling rollback.
+
+#. When in doubt, install both legacy boot
+   and EFI.
 
 #. If using legacy booting, install GRUB to every disk::
 
@@ -104,6 +104,7 @@ Install GRUB
 #. For both legacy and EFI booting: mirror ESP content::
 
     ESP_MIRROR=$(mktemp -d)
+    unalias -a
     cp -r /boot/efi/EFI $ESP_MIRROR
     for i in /boot/efis/*; do
      cp -r $ESP_MIRROR/EFI $i

--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/6-recovery.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/6-recovery.rst
@@ -187,21 +187,21 @@ it is relatively easy to perform a system backup and migration.
 
 #. Create a snapshot of root file system::
 
-    zfs snapshot -r rpool/arch@backup
-    zfs snapshot -r bpool/arch@backup
+    zfs snapshot -r rpool/$INST_ID@backup
+    zfs snapshot -r bpool/$INST_ID@backup
 
 #. Save snapshot to a file or pipe to SSH::
 
-    zfs send --options rpool/arch@backup > /backup/arch-rpool
-    zfs send --options bpool/arch@backup > /backup/arch-bpool
+    zfs send --options rpool/$INST_ID@backup > /backup/$INST_ID-rpool
+    zfs send --options bpool/$INST_ID@backup > /backup/$INST_ID-bpool
 
 #. Re-create partitions and root/boot
    pool on target system.
 
 #. Restore backup::
 
-    zfs recv rpool_new/arch < /backup/arch-rpool
-    zfs recv bpool_new/arch < /backup/arch-bpool
+    zfs recv rpool_new/$INST_ID < /backup/$INST_ID-rpool
+    zfs recv bpool_new/$INST_ID < /backup/$INST_ID-bpool
 
 #. Chroot and reinstall bootloader.
 

--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/6-recovery.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/6-recovery.rst
@@ -21,13 +21,14 @@ This section is also applicable if you are in
 #. On another computer, generate rescue image with::
 
      pacman -S --needed mtools libisoburn grub
+     grub-install
      grub-mkrescue -o grub-rescue.img
      dd if=grub-rescue.img of=/dev/your-usb-stick
 
    Boot computer from the rescue media.
    Both legacy and EFI mode are supported.
 
-   Skip this step if you are in GRUB rescue.
+   Or `download generated GRUB rescue image <https://gitlab.com/m_zhou/bieaz/uploads/4a1b7cefb42723de6eb04f9dc485be3b/grub-rescue.img.7z>`__.
 
 #. List available disks with ``ls`` command::
 
@@ -35,20 +36,6 @@ This section is also applicable if you are in
     Possible devices are:
 
      hd0 hd1 hd2 hd3
-
-   If you are dropped to GRUB rescue instead of
-   booting from GRUB rescue image, boot disk can be found
-   out with::
-
-    echo $root
-    # cryto0
-    # hd0,gpt2
-
-   GRUB configuration is loaded from::
-
-    echo $prefix
-    # (crypto0)/sys/BOOT/default@/grub
-    # (hd0,gpt2)/sys/BOOT/default@/grub
 
 #. List partitions by pressing tab key:
 
@@ -94,12 +81,10 @@ This section is also applicable if you are in
      grub> ls (crypto0)/sys/BOOT
      @/ default/ be0/
 
-#. Instruct GRUB to load configuration from ``be0`` boot environment
-   then enter normal mode::
+#. Instruct GRUB to load configuration from ``be0`` boot environment::
 
      grub> prefix=(crypto0)/sys/BOOT/be0/@/grub
-     grub> insmod normal
-     grub> normal
+     grub> configfile $prefix/grub.cfg
 
 #. GRUB menu should now appear.
 
@@ -188,7 +173,7 @@ Access system in chroot
 
 #. chroot into the system::
 
-     rhel-chroot /mnt /bin/bash --login
+     arch-chroot /mnt /bin/bash --login
      zfs mount -a
      mount -a
 
@@ -202,21 +187,21 @@ it is relatively easy to perform a system backup and migration.
 
 #. Create a snapshot of root file system::
 
-    zfs snapshot -r rpool/rhel@backup
-    zfs snapshot -r bpool/rhel@backup
+    zfs snapshot -r rpool/arch@backup
+    zfs snapshot -r bpool/arch@backup
 
 #. Save snapshot to a file or pipe to SSH::
 
-    zfs send --options rpool/rhel@backup > /backup/rhel-rpool
-    zfs send --options bpool/rhel@backup > /backup/rhel-bpool
+    zfs send --options rpool/arch@backup > /backup/arch-rpool
+    zfs send --options bpool/arch@backup > /backup/arch-bpool
 
 #. Re-create partitions and root/boot
    pool on target system.
 
 #. Restore backup::
 
-    zfs recv rpool_new/rhel < /backup/rhel-rpool
-    zfs recv bpool_new/rhel < /backup/rhel-bpool
+    zfs recv rpool_new/arch < /backup/arch-rpool
+    zfs recv bpool_new/arch < /backup/arch-bpool
 
 #. Chroot and reinstall bootloader.
 

--- a/docs/Getting Started/RHEL-based distro/index.rst
+++ b/docs/Getting Started/RHEL-based distro/index.rst
@@ -42,7 +42,8 @@ For RHEL/CentOS versions 6 and 7 run::
 
 And for RHEL/CentOS 8 and newer::
 
- dnf install https://zfsonlinux.org/epel/zfs-release$(rpm -E %distro).noarch.rpm
+ source /etc/os-release
+ dnf install https://zfsonlinux.org/epel/zfs-release.el${VERSION_ID/./_}.noarch.rpm
  rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux
 
 After installing the *zfs-release* package and verifying the public key


### PR DESCRIPTION
I've just completed a test installation and fixed some minor issues with Fedora guide.

A major addition is the switch from Fedora 34 Live ISO to RockyLinux 8 Live ISO. The latter ISO was published after the guide was written a month ago.

This switch solved the problem of conflicting package versions between Fedora Live and RockyLinux installation. Relevant changes have been included in this PR.

Firewall is enabled by default for enhanced security.
@gmelikov 

Signed-off-by: Maurice Zhou <jasper@apvc.uk>