### PR TITLE
Build site with alpine

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,21 +9,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Prepare
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y git python3-pip mandoc
-        pip install -r docs/requirements.txt
-    - name: Gen_man_pages
-      run: make man
-    - name: Gen_feature_matrix
-      run: make feature_matrix
-    - name: Gen_sphinx
-      uses: ammaraskar/sphinx-action@master
-      with:
-        pre-build-command: "apt-get update -y && apt-get install -y git"
-        docs-folder: "docs/"
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Build
+      uses: ./
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,22 +6,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Prepare
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y git python3-pip mandoc
-        pip install -r docs/requirements.txt
-    - name: Gen_man_pages
-      run: make man
-    - name: Gen_feature_matrix
-      run: make feature_matrix
-    - name: Gen_sphinx
-      uses: ammaraskar/sphinx-action@master
-      with:
-        pre-build-command: "apt-get update -y && apt-get install -y git"
-        docs-folder: "docs/"
-    - uses: actions/upload-artifact@v2
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Build
+      uses: ./
+    - name: Upload
+      uses: actions/upload-artifact@v2
       with:
         name: DocumentationHTML
         path: docs/_build/html/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# Container image that runs your code
+FROM alpine:latest
+
+# Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+# Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,6 @@
+# action.yml
+name: 'sitegen'
+description: 'Generate website'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ import sphinx_rtd_theme
 # -- Project information -----------------------------------------------------
 
 project = u'OpenZFS'
-copyright = u'2020, OpenZFS'
+copyright = u'2021, OpenZFS'
 author = u'OpenZFS'
 
 # The short X.Y version

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+apk add git py3-pip mandoc make
+pip install -r docs/requirements.txt
+make man
+make feature_matrix
+make html


### PR DESCRIPTION
Use Alpine for building site.

- Time for building site is reduced from [~2min](https://github.com/openzfs/openzfs-docs/actions/runs/1115238774) to [~1min](https://github.com/ne9z/openzfs-docs/actions/runs/1154748486), see respective pages for details.
- Remove 3rd-party dependency `ammaraskar/sphinx-action@master`, less potential breakage.
- Update actions/checkout from v1 to v2, for publish.yml

Built site can be viewed at https://ne9z.github.io/openzfs-docs/

@gmelikov 

Signed-off-by: Maurice Zhou <jasper@apvc.uk>