### PR TITLE
CI: hotfix for Debian repos' Suite change

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Gen_sphinx
       uses: ammaraskar/sphinx-action@master
       with:
-        pre-build-command: "apt-get update -y && apt-get install -y git"
+        pre-build-command: "apt-get update -y --allow-releaseinfo-change && apt-get install -y git"
         docs-folder: "docs/"
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Gen_sphinx
       uses: ammaraskar/sphinx-action@master
       with:
-        pre-build-command: "apt-get update -y && apt-get install -y git"
+        pre-build-command: "apt-get update -y --allow-releaseinfo-change && apt-get install -y git"
         docs-folder: "docs/"
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Debian published new release and changed `Suite` for previous release. Just allow it for `apt update`.