### PR TITLE
Always use mirrored vdev for boot pool

### DIFF
--- a/docs/Getting Started/Arch Linux/Root on ZFS/1-preparation.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS/1-preparation.rst
@@ -120,6 +120,9 @@ Preparation
    `here <https://www.delphix.com/blog/delphix-engineering/zfs-raidz-stripe-width-or-how-i-learned-stop-worrying-and-love-raidz>`__
    and `here <https://docs.google.com/spreadsheets/d/1tf4qx1aMJp8Lo_R6gpT689wTjHv6CGVElrPqTA0w_ZY/>`__.
 
+   For boot pool, which must be readable by GRUB, mirrored vdev should always be used for maximum redundancy.
+   This guide will use mirrored bpool for multi-disk setup.
+
    Refer to `zpoolconcepts <https://openzfs.github.io/openzfs-docs/man/7/zpoolconcepts.7.html>`__
    and `zpool-create <https://openzfs.github.io/openzfs-docs/man/8/zpool-create.8.html>`__
    man pages for details.

--- a/docs/Getting Started/Arch Linux/Root on ZFS/2-system-installation.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS/2-system-installation.rst
@@ -43,6 +43,9 @@ System Installation
 
 #. Create boot pool::
 
+    disk_num=0; for i in $DISK; do disk_num=$(( $disk_num + 1 )); done
+    if [ $disk_num -gt 1 ]; then INST_VDEV_BPOOL=mirror; fi
+
     zpool create \
         -o compatibility=grub2 \
         -o ashift=12 \
@@ -57,7 +60,7 @@ System Installation
         -O mountpoint=/boot \
         -R /mnt \
         bpool_$INST_UUID \
-        $INST_VDEV \
+         $INST_VDEV_BPOOL \
         $(for i in ${DISK}; do
            printf "$i-part2 ";
           done)

--- a/docs/Getting Started/Arch Linux/Root on ZFS/4-optional-configuration.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS/4-optional-configuration.rst
@@ -119,6 +119,10 @@ root pool will be replaced by keyfile, embedded in initrd.
 
 #. Recreate boot pool with mappers as vdev::
 
+    disk_num=0; for i in $DISK; do disk_num=$(( $disk_num + 1 )); done
+    if [ $disk_num -gt 1 ]; then INST_VDEV_BPOOL=mirror; fi
+
+
     zpool create \
         -o compatibility=grub2 \
         -o ashift=12 \
@@ -132,7 +136,7 @@ root pool will be replaced by keyfile, embedded in initrd.
         -O xattr=sa \
         -O mountpoint=/boot \
         bpool_$INST_UUID \
-        $INST_VDEV \
+         $INST_VDEV_BPOOL \
         $(for i in ${DISK}; do
            printf "/dev/mapper/${i##*/}-part2-luks-bpool_$INST_UUID ";
           done)

--- a/docs/Getting Started/Arch Linux/index.rst
+++ b/docs/Getting Started/Arch Linux/index.rst
@@ -82,4 +82,4 @@ Contribute
     sensible-browser _build/html/index.html
 
 #. ``git commit --signoff`` to a branch, ``git push``, and create a pull
-   request. Mention @rlaager.
+   request. Mention @ne9z.

--- a/docs/Getting Started/Fedora/Root on ZFS/1-preparation.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/1-preparation.rst
@@ -113,6 +113,9 @@ Preparation
    `here <https://www.delphix.com/blog/delphix-engineering/zfs-raidz-stripe-width-or-how-i-learned-stop-worrying-and-love-raidz>`__
    and `here <https://docs.google.com/spreadsheets/d/1tf4qx1aMJp8Lo_R6gpT689wTjHv6CGVElrPqTA0w_ZY/>`__.
 
+   For boot pool, which must be readable by GRUB, mirrored vdev should always be used for maximum redundancy.
+   This guide will use mirrored bpool for multi-disk setup.
+
    Refer to `zpoolconcepts <https://openzfs.github.io/openzfs-docs/man/7/zpoolconcepts.7.html>`__
    and `zpool-create <https://openzfs.github.io/openzfs-docs/man/8/zpool-create.8.html>`__
    man pages for details.

--- a/docs/Getting Started/Fedora/Root on ZFS/2-system-installation.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/2-system-installation.rst
@@ -43,6 +43,11 @@ System Installation
 
 #. Create boot pool::
 
+
+    disk_num=0; for i in $DISK; do disk_num=$(( $disk_num + 1 )); done
+    if [ $disk_num -gt 1 ]; then INST_VDEV_BPOOL=mirror; fi
+
+
     zpool create \
         -o compatibility=grub2 \
         -o ashift=12 \
@@ -57,7 +62,7 @@ System Installation
         -O mountpoint=/boot \
         -R /mnt \
         bpool_$INST_UUID \
-        $INST_VDEV \
+         $INST_VDEV_BPOOL \
         $(for i in ${DISK}; do
            printf "$i-part2 ";
           done)

--- a/docs/Getting Started/Fedora/Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/3-system-configuration.rst
@@ -101,7 +101,7 @@ System Configuration
 
 #. Build ZFS modules::
 
-    ls -1 /lib/modules \
-    | while read kernel_version; do
+    for directory in /lib/modules/*; do
+      kernel_version=$(basename $directory)
       dkms autoinstall -k $kernel_version
-      done
+    done

--- a/docs/Getting Started/Fedora/Root on ZFS/5-bootloader.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/5-bootloader.rst
@@ -49,10 +49,10 @@ Install GRUB
     touch /etc/zfs/zpool.cache
     chmod a-w /etc/zfs/zpool.cache
     chattr +i /etc/zfs/zpool.cache
-    ls -1 /lib/modules \
-    | while read kernel_version; do
+    for directory in /lib/modules/*; do
+      kernel_version=$(basename $directory)
       dracut --force --kver $kernel_version
-      done
+    done
 
 #. Disable BLS::
 

--- a/docs/Getting Started/Fedora/index.rst
+++ b/docs/Getting Started/Fedora/index.rst
@@ -45,12 +45,15 @@ see below.
 
     modprobe zfs
 
-   It might be necessary to rebuild module::
+   It might be necessary to rebuild ZFS module::
 
-    ls -1 /lib/modules \
-    | while read kernel_version; do
+    for directory in /lib/modules/*; do
+      kernel_version=$(basename $directory)
       dkms autoinstall -k $kernel_version
     done
+
+   If for some reason, ZFS kernel module is not successfully built,
+   you can also run the above command to debug the problem.
 
 #. By default ZFS kernel modules are loaded upon detecting a pool.
    To always load the modules at boot::

--- a/docs/Getting Started/NixOS/Root on ZFS/1-preparation.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/1-preparation.rst
@@ -82,6 +82,9 @@ Preparation
    `here <https://www.delphix.com/blog/delphix-engineering/zfs-raidz-stripe-width-or-how-i-learned-stop-worrying-and-love-raidz>`__
    and `here <https://docs.google.com/spreadsheets/d/1tf4qx1aMJp8Lo_R6gpT689wTjHv6CGVElrPqTA0w_ZY/>`__.
 
+   For boot pool, which must be readable by GRUB, mirrored vdev should always be used for maximum redundancy.
+   This guide will use mirrored bpool for multi-disk setup.
+
    Refer to `zpoolconcepts <https://openzfs.github.io/openzfs-docs/man/7/zpoolconcepts.7.html>`__
    and `zpool-create <https://openzfs.github.io/openzfs-docs/man/8/zpool-create.8.html>`__
    man pages for details.

--- a/docs/Getting Started/NixOS/Root on ZFS/2-system-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/2-system-configuration.rst
@@ -43,6 +43,11 @@ System Configuration
 
 #. Create boot pool::
 
+
+    disk_num=0; for i in $DISK; do disk_num=$(( $disk_num + 1 )); done
+    if [ $disk_num -gt 1 ]; then INST_VDEV_BPOOL=mirror; fi
+
+
     zpool create \
     -d -o feature@async_destroy=enabled \
     -o feature@bookmarks=enabled \
@@ -67,7 +72,7 @@ System Configuration
         -O mountpoint=/boot \
         -R /mnt \
         bpool_$INST_UUID \
-        $INST_VDEV \
+         $INST_VDEV_BPOOL \
         $(for i in ${DISK}; do
            printf "$i-part2 ";
           done)

--- a/docs/Getting Started/NixOS/Root on ZFS/3-optional-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/3-optional-configuration.rst
@@ -114,6 +114,10 @@ root pool will be replaced by keyfile, embedded in initrd.
 
 #. Recreate boot pool with mappers as vdev::
 
+    disk_num=0; for i in $DISK; do disk_num=$(( $disk_num + 1 )); done
+    if [ $disk_num -gt 1 ]; then INST_VDEV_BPOOL=mirror; fi
+
+
     zpool create \
         -d -o feature@async_destroy=enabled \
         -o feature@bookmarks=enabled \
@@ -138,7 +142,7 @@ root pool will be replaced by keyfile, embedded in initrd.
         -O mountpoint=/boot \
         -R /mnt \
         bpool_$INST_UUID \
-        $INST_VDEV \
+         $INST_VDEV_BPOOL \
         $(for i in ${DISK}; do
            printf "/dev/mapper/${i##*/}-part2-luks-bpool_$INST_UUID ";
           done)

--- a/docs/Getting Started/NixOS/Root on ZFS/4-system-installation.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/4-system-installation.rst
@@ -26,15 +26,14 @@ of declaratively configuring the system.
 
 #. Generate password hash::
 
-    mkpasswd -m SHA-512 -s
-    #output: $6$DeHnzc
+    INST_ROOT_PASSWD=$(mkpasswd -m SHA-512 -s)
 
 #. Declare `initialHashedPassword
    <https://nixos.org/manual/nixos/stable/options.html#opt-users.users._name_.initialHashedPassword>`__
    for root user::
 
-    tee -a /mnt/etc/nixos/${INST_CONFIG_FILE} <<-'EOF'
-      users.users.root.initialHashedPassword = "$6$DeHnzc";
+    tee -a /mnt/etc/nixos/${INST_CONFIG_FILE} <<EOF
+      users.users.root.initialHashedPassword = "${INST_ROOT_PASSWD}";
     EOF
 
 System installation

--- a/docs/Getting Started/NixOS/index.rst
+++ b/docs/Getting Started/NixOS/index.rst
@@ -89,4 +89,4 @@ Contribute
     sensible-browser _build/html/index.html
 
 #. ``git commit --signoff`` to a branch, ``git push``, and create a pull
-   request. Mention @rlaager.
+   request. Mention @ne9z.

--- a/docs/Getting Started/NixOS/index.rst
+++ b/docs/Getting Started/NixOS/index.rst
@@ -62,3 +62,31 @@ An installation guide is available.
   :glob:
 
   Root on ZFS/*
+
+Contribute
+----------
+#. Fork and clone `this repo <https://github.com/openzfs/openzfs-docs>`__.
+
+#. Launch an ephemeral nix-shell with the following packages::
+
+    nix-shell -p python39 python39Packages.pip gnumake \
+        python39Packages.setuptools python39Packages.sphinx
+
+#. Create python virtual environment and install packages::
+
+    cd openzfs-docs
+    python -m venv .venv
+    source .venv/bin/activate
+
+    pip install -r docs/requirements.txt
+
+#. Make your changes.
+
+#. Test::
+
+    cd docs
+    make html
+    sensible-browser _build/html/index.html
+
+#. ``git commit --signoff`` to a branch, ``git push``, and create a pull
+   request. Mention @rlaager.

--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/1-preparation.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/1-preparation.rst
@@ -119,6 +119,9 @@ Preparation
    `here <https://www.delphix.com/blog/delphix-engineering/zfs-raidz-stripe-width-or-how-i-learned-stop-worrying-and-love-raidz>`__
    and `here <https://docs.google.com/spreadsheets/d/1tf4qx1aMJp8Lo_R6gpT689wTjHv6CGVElrPqTA0w_ZY/>`__.
 
+   For boot pool, which must be readable by GRUB, mirrored vdev should always be used for maximum redundancy.
+   This guide will use mirrored bpool for multi-disk setup.
+
    Refer to `zpoolconcepts <https://openzfs.github.io/openzfs-docs/man/7/zpoolconcepts.7.html>`__
    and `zpool-create <https://openzfs.github.io/openzfs-docs/man/8/zpool-create.8.html>`__
    man pages for details.

--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/2-system-installation.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/2-system-installation.rst
@@ -43,6 +43,11 @@ System Installation
 
 #. Create boot pool::
 
+
+    disk_num=0; for i in $DISK; do disk_num=$(( $disk_num + 1 )); done
+    if [ $disk_num -gt 1 ]; then INST_VDEV_BPOOL=mirror; fi
+
+
     zpool create \
     -d -o feature@async_destroy=enabled \
     -o feature@bookmarks=enabled \
@@ -67,7 +72,7 @@ System Installation
         -O mountpoint=/boot \
         -R /mnt \
         bpool_$INST_UUID \
-        $INST_VDEV \
+         $INST_VDEV_BPOOL \
         $(for i in ${DISK}; do
            printf "$i-part2 ";
           done)

--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/3-system-configuration.rst
@@ -97,7 +97,7 @@ System Configuration
 
 #. Build ZFS modules::
 
-    ls -1 /lib/modules \
-    | while read kernel_version; do
+    for directory in /lib/modules/*; do
+      kernel_version=$(basename $directory)
       dkms autoinstall -k $kernel_version
-      done
+    done

--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/5-bootloader.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/5-bootloader.rst
@@ -49,10 +49,10 @@ Install GRUB
     touch /etc/zfs/zpool.cache
     chmod a-w /etc/zfs/zpool.cache
     chattr +i /etc/zfs/zpool.cache
-    ls -1 /lib/modules \
-    | while read kernel_version; do
+    for directory in /lib/modules/*; do
+      kernel_version=$(basename $directory)
       dracut --force --kver $kernel_version
-      done
+    done
 
 #. Load ZFS modules and disable BLS::
 

--- a/docs/Getting Started/RHEL-based distro/index.rst
+++ b/docs/Getting Started/RHEL-based distro/index.rst
@@ -109,6 +109,16 @@ time you must create an ``/etc/modules-load.d/zfs.conf`` file::
    After upgrading users must uninstall OpenZFS and then reinstall it
    from the matching repository as described in this section.
 
+It might be necessary to rebuild ZFS module::
+
+ for directory in /lib/modules/*; do
+   kernel_version=$(basename $directory)
+   dkms autoinstall -k $kernel_version
+ done
+
+If for some reason, ZFS kernel module is not successfully built,
+you can also run the above command to debug the problem.
+
 Testing Repositories
 --------------------
 


### PR DESCRIPTION
I just stumbled across [this issue](https://github.com/openzfs/zfs/pull/11763), 
where discussion concluded that GRUB does not support indirect vdevs and will not be able to read the pool even if there's enough redundancy.

This reminded me that we must ensure boot pool is always readable by GRUB and unaffected by any new pool feature what-so-ever. Or else the computer will not be able to boot at all.

This commit changes the guide to use mirrored vdev for boot pool under all circumstances except single disk installation.

@gmelikov 