### PR TITLE
Add `dnf remove -y zfs-fuse` step to fedora preparation doc

### DIFF
--- a/docs/Getting Started/Fedora/Root on ZFS/1-preparation.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/1-preparation.rst
@@ -38,6 +38,10 @@ Preparation
 
     dnf install -y https://zfsonlinux.org/fedora/zfs-release.fc${VERSION_ID}.noarch.rpm
 
+#. If zfs-fuse from official Fedora repo is installed, remove it first. It is not maintained and should not be used under any circumstance::
+
+    dnf remove -y zfs-fuse
+
 #. Install ZFS packages::
 
     dnf install -y zfs


### PR DESCRIPTION
I followed the preparation doc for installing zfs on root on fedora for the first time, but got an error at the `dnf install -y zfs` step:

```
# dnf install -y zfs
ZFS on Linux for Fedora 34                                                                                      142 kB/s | 199 kB     00:01
Last metadata expiration check: 0:00:01 ago on Fri 17 Sep 2021 10:29:51 PM EDT.
Error:
 Problem: problem with installed package zfs-fuse-0.7.2.2-18.fc34.x86_64
  - package zfs-2.0.4-1.fc34.x86_64 conflicts with zfs-fuse provided by zfs-fuse-0.7.2.2-18.fc34.x86_64
  - conflicting requests
  - package zfs-2.0.5-1.fc34.x86_64 conflicts with zfs-fuse provided by zfs-fuse-0.7.2.2-18.fc34.x86_64
  - package zfs-2.1.0-1.fc34.x86_64 conflicts with zfs-fuse provided by zfs-fuse-0.7.2.2-18.fc34.x86_64
  - package zfs-2.1.1-1.fc34.x86_64 conflicts with zfs-fuse provided by zfs-fuse-0.7.2.2-18.fc34.x86_64
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
```

I was able to work around this by following the first step in [index.rst](https://openzfs.github.io/openzfs-docs/Getting%20Started/Fedora/index.html#testing-repo) to `dnf remove -y zfs-fuse` first.

This change makes the preparation document align with the same recommendation in index.rst. I added this step as late as possible in the list of steps that still prevents the issue I encountered.