### PR TITLE
add `keymap` hook to initrd

### DIFF
--- a/docs/Getting Started/Arch Linux/Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS/3-system-configuration.rst
@@ -36,7 +36,7 @@ System Configuration
 
     mv /mnt/etc/mkinitcpio.conf /mnt/etc/mkinitcpio.conf.original
     tee /mnt/etc/mkinitcpio.conf <<EOF
-    HOOKS=(base udev autodetect modconf block keyboard zfs filesystems)
+    HOOKS=(base udev autodetect modconf block keyboard keymap zfs filesystems)
     EOF
 
 #. Enable DHCP on all ethernet ports::


### PR DESCRIPTION
Add `keymap` hook to initrd for correct keyboard layout on decryption password input.

https://wiki.archlinux.org/title/Mkinitcpio#Common_hooks