### PR TITLE
Update instructions for Ubuntu on Raspberry Pi for 20.04.3 release.

### DIFF
--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
@@ -20,8 +20,8 @@ System Requirements
 
 - A Raspberry Pi 4 B. (If you are looking to install on a regular PC, see
   :doc:`Ubuntu 20.04 Root on ZFS`.)
-- `Ubuntu Server 20.04.2 (“Focal”) for Raspberry Pi 4
-  <https://cdimage.ubuntu.com/releases/20.04.2/release/ubuntu-20.04.2-preinstalled-server-arm64+raspi.img.xz>`__
+- `Ubuntu Server 20.04.3 (“Focal”) for Raspberry Pi 4
+  <https://cdimage.ubuntu.com/releases/20.04.3/release/ubuntu-20.04.3-preinstalled-server-arm64+raspi.img.xz>`__
 - A microSD card. For recommendations, see Jeff Geerling's `performance
   comparison
   <https://www.jeffgeerling.com/blog/2019/raspberry-pi-microsd-card-performance-comparison-2019>`__.
@@ -107,30 +107,30 @@ be deleted.
 
 #. Download and unpack the official image::
 
-    curl -O https://cdimage.ubuntu.com/releases/20.04.2/release/ubuntu-20.04.2-preinstalled-server-arm64+raspi.img.xz
-    xz -d ubuntu-20.04.2-preinstalled-server-arm64+raspi.img.xz
+    curl -O https://cdimage.ubuntu.com/releases/20.04.3/release/ubuntu-20.04.3-preinstalled-server-arm64+raspi.img.xz
+    xz -d ubuntu-20.04.3-preinstalled-server-arm64+raspi.img.xz
 
     # or combine them to decompress as you download:
-    curl https://cdimage.ubuntu.com/releases/20.04.2/release/ubuntu-20.04.2-preinstalled-server-arm64+raspi.img.xz | \
-        xz -d > ubuntu-20.04.2-preinstalled-server-arm64+raspi.img
+    curl https://cdimage.ubuntu.com/releases/20.04.3/release/ubuntu-20.04.3-preinstalled-server-arm64+raspi.img.xz | \
+        xz -d > ubuntu-20.04.3-preinstalled-server-arm64+raspi.img
 
 #. Dump the partition table for the image::
 
-     sfdisk -d ubuntu-20.04.2-preinstalled-server-arm64+raspi.img
+     sfdisk -d ubuntu-20.04.3-preinstalled-server-arm64+raspi.img
 
    That will output this::
 
      label: dos
-     label-id: 0x4ec8ea53
-     device: ubuntu-20.04.2-preinstalled-server-arm64+raspi.img
+     label-id: 0xf66f0719
+     device: ubuntu-20.04.3-preinstalled-server-arm64+raspi.img
      unit: sectors
      <name>.img1 : start=        2048, size=      524288, type=c, bootable
-     <name>.img2 : start=      526336, size=     5839840, type=83
+     <name>.img2 : start=      526336, size=     6052348, type=83
 
-   The important numbers are 524288 and 5839840.  Store those in variables::
+   The important numbers are 524288 and 6052348.  Store those in variables::
 
      export BOOT=524288
-     export ROOT=5839840
+     export ROOT=6052348
 
 #. Create a partition script::
 
@@ -186,7 +186,7 @@ be deleted.
 #. Loopback mount the image::
 
      IMG=$(sudo losetup -fP --show \
-               ubuntu-20.04.2-preinstalled-server-arm64+raspi.img)
+               ubuntu-20.04.3-preinstalled-server-arm64+raspi.img)
 
 #. Copy the bootloader data::
 


### PR DESCRIPTION
Update the getting started instructions for Ubuntu on a Raspberry Pi to use the 20.04.3 LTS release.
@rlaager 