### PR TITLE
Root on ZFS Raspberry Pi for USB SSDs

### DIFF
--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
@@ -12,7 +12,7 @@ Overview
 Caution
 ~~~~~~~
 
-- This HOWTO uses a whole physical SD card.
+- This HOWTO uses a whole physical disk.
 - Backup your data. Any existing data will be lost.
 
 System Requirements
@@ -22,11 +22,13 @@ System Requirements
   :doc:`Ubuntu 20.04 Root on ZFS`.)
 - `Ubuntu Server 20.04.3 (“Focal”) for Raspberry Pi 4
   <https://cdimage.ubuntu.com/releases/20.04.3/release/ubuntu-20.04.3-preinstalled-server-arm64+raspi.img.xz>`__
-- A microSD card or USB disk. For microSD card recommendations, see Jeff Geerling's `performance
-  comparison
+- A microSD card or USB disk. For microSD card recommendations, see Jeff
+  Geerling's `performance comparison
   <https://www.jeffgeerling.com/blog/2019/raspberry-pi-microsd-card-performance-comparison-2019>`__.
-- An Ubuntu system (with the ability to write to the SD card or USB disk) other than the
-  target Raspberry Pi.
+  When using a USB enclosure, `ensure it supports UASP
+  <https://github.com/geerlingguy/turing-pi-cluster/issues/11#issuecomment-647726561>`__.
+- An Ubuntu system (with the ability to write to the microSD card or USB disk)
+  other than the target Raspberry Pi.
 
 4 GiB of memory is recommended. Do not use deduplication, as it needs `massive
 amounts of RAM <http://wiki.freebsd.org/ZFSTuningGuide#Deduplication>`__.
@@ -97,34 +99,48 @@ entered at the console. Performance is good, but LUKS sits underneath ZFS, so
 if multiple disks (mirror or raidz topologies) are used, the data has to be
 encrypted once per disk.
 
-USB Solid State Drives (SSDs)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+USB Disks
+~~~~~~~~~
 
-The Raspberry Pi 4 runs much faster using a USB SSD than an SD card. These
-instructions can also be used to install Ubuntu on a USB-connected Solid
-State Drive (SSD) or other USB disk. USB disks have three requirements that
-do not apply to SD cards:
+The Raspberry Pi 4 runs much faster using a USB Solid State Drive (SSD) than
+a microSD card. These instructions can also be used to install Ubuntu on a
+USB-connected SSD or other USB disk. USB disks have three requirements that
+do not apply to microSD cards:
 
-#. The Raspberry Pi's Bootloader EEPROM must be dated 2020-09-21 or later.
+#. The Raspberry Pi's Bootloader EEPROM must be dated 2020-09-03 or later.
 
-   - To check the firmware version, power up the Raspberry Pi without an SD card
-     inserted or a USB boot device attached; the firmware date will be on the
-     ``bootloader`` line. Alternatively, run ``sudo rpi-eeprom-update`` with the
-     Raspberry Pi booted into Raspberry Pi OS.
-   - `Update the EEPROM firmware <https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#updating-the-bootloader>`_ if needed.
+   To check the bootloader version, power up the Raspberry Pi without an SD
+   card inserted or a USB boot device attached; the date will be on the
+   ``bootloader`` line. (If you do not see the ``bootloader`` line, the
+   bootloader is too old.) Alternatively, run ``sudo rpi-eeprom-update``
+   on an existing OS on the Raspberry Pi (which on Ubuntu requires
+   ``apt install rpi-eeprom``).
 
-#. The Raspberry Pi must configured for USB boot. The simplest way enable USB boot is
+   If needed, the bootloader can be updated from an existing OS on the
+   Raspberry Pi using ``rpi-eeprom-update -a`` and rebooting.
+   For other options, see `Updating the Bootloader
+   <https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#updating-the-bootloader>`_.
 
-   - Download the `Raspberry Pi Imager Utility <https://www.raspberrypi.com/news/raspberry-pi-imager-imaging-utility/>`_.
-   - Flash the ``USB Boot`` image to an SD card. The ``USB Boot`` image is
+#. The Raspberry Pi must configured for USB boot. The bootloader will show a
+   ``boot`` line; if ``order`` includes ``4``, USB boot is enabled.
+
+   If not already enabled, it can be enabled from an existing OS on the
+   Raspberry Pi using ``rpi-eeprom-config -e``: set ``BOOT_ORDER=0xf41``
+   and reboot to apply the change. On subsequent reboots, USB boot will be
+   enabled.
+
+   Otherwise, it can be enabled without an existing OS as follows:
+
+   - Download the `Raspberry Pi Imager Utility
+     <https://www.raspberrypi.com/news/raspberry-pi-imager-imaging-utility/>`_.
+   - Flash the ``USB Boot`` image to a microSD card. The ``USB Boot`` image is
      listed under ``Bootload`` in the ``Misc utility images`` folder.
-   - Boot the Raspberry Pi from the SD card. USB Boot should be enabled
+   - Boot the Raspberry Pi from the microSD card. USB Boot should be enabled
      automatically.
 
 #. The Ubuntu Linux kernel must not be compressed. These instructions
-   decompress the kernel and add a script to `/etc/kernel/postinst.d` to keep
-   the kernel decompressed when the kernel is upgraded or otherwise changed.
-   This script is not sanctioned by Ubuntu. Use at your own risk.
+   decompress the kernel and add a script to ``/etc/kernel/postinst.d`` to
+   handle kernel upgrades.
 
 Step 1: Disk Formatting
 -----------------------
@@ -172,25 +188,26 @@ be deleted.
      3 : start=$((2048+BOOT+ROOT)), size=$ROOT, type=83
      EOF
 
-#. Connect the SD card or USB disk:
+#. Connect the disk:
 
-   Connect the SD card to a machine other than the target Raspberry Pi.  If
-   any filesystems are automatically mounted (e.g. by GNOME) unmount them.
-   Determine the device name. (For SD, the device name is almost certainly
-   ``/dev/mmcblk0``). For USB SSDs, the device name is ``/dev/sdX``, where `X` is
-   a lowercase letter. ``lsblk`` can help determine the device name.
+   Connect the disk to a machine other than the target Raspberry Pi.  If any
+   filesystems are automatically mounted (e.g. by GNOME) unmount them.
+   Determine the device name. For SD, the device name is almost certainly
+   ``/dev/mmcblk0``. For USB SSDs, the device name is ``/dev/sdX``, where
+   ``X`` is a lowercase letter. ``lsblk`` can help determine the device name.
    Set the ``DISK`` environment variable to the device name::
 
-     export DISK=/dev/mmcblk0    # SD card
-     export DISK=/dev/sdX        # USB disk
+     DISK=/dev/mmcblk0    # microSD card
+     DISK=/dev/sdX        # USB disk
 
    Because partitions are named differently for ``/dev/mmcblk0`` and ``/dev/sdX``
    devices, set a second variable used when working with partitions::
 
-     export DISKP=${DISK}p       # SD card
-     export DISKP=${DISK}        # USB disk ($DISKP == $DISK for /dev/sdX devices)
+     export DISKP=${DISK}p # microSD card
+     export DISKP=${DISK}  # USB disk ($DISKP == $DISK for /dev/sdX devices)
 
-   **Hint**: SD cards connected using a USB reader also have ``/dev/sdX`` names.
+   **Hint**: microSD cards connected using a USB reader also have ``/dev/sdX``
+   names.
 
    **WARNING**: The following steps destroy the existing data on the disk. Ensure
    ``DISK`` and ``DISKP`` are correct before proceeding.
@@ -198,7 +215,7 @@ be deleted.
 #. Ensure swap partitions are not in use::
 
      swapon -v
-     # If a partition is in use from the SD card, disable it:
+     # If a partition is in use from the disk, disable it:
      sudo swapoff THAT_PARTITION
 
 #. Clear old ZFS labels::
@@ -251,7 +268,7 @@ be deleted.
 
      sudo losetup -d $IMG
 
-#. If setting up a USB disk, setup decompressed kernel and boot config.
+#. If setting up a USB disk:
 
    Decompress the kernel::
 
@@ -263,30 +280,14 @@ be deleted.
      mount ${DISKP}3 $MNT/root
 
      zcat -qf $MNT/boot/vmlinuz >$MNT/boot/vmlinux
-     touch -r $MNT/boot/vmlinuz $MNT/boot/vmlinux
 
-   Modify boot config.txt::
+   Modify boot config::
 
-     [ ! -f $MNT/boot/config.txt.original ] \
-         && cp $MNT/boot/config.txt $MNT/boot/config.txt.original
-     awk '
-         /^\[pi4\][[:blank:]]*$/ {
-             state="pi4"
-         }
-         state == "pi4" && /kernel=/ {
-             print "kernel=vmlinux"
-             next
-         }
-         state == "pi4" && /^[[:blank:]]*$/ {
-             print "dtoverlay=vc4-fkms-v3d"
-             print "initramfs initrd.img followkernel"
-             print "boot_delay"
-             state = ""
-         }
-         { print }
-     ' $MNT/boot/config.txt >$MNT/boot/config.txt.new
-     mv -f $MNT/boot/config.txt.new $MNT/boot/config.txt
-     chmod --reference $MNT/boot/config.txt.original $MNT/boot/config.txt
+     cat >> $MNT/boot/usercfg.txt << EOF
+     kernel=vmlinux
+     initramfs initrd.img followkernel
+     boot_delay
+     EOF
 
    Create a script to automatically decompress the kernel after an upgrade::
 
@@ -295,33 +296,25 @@ be deleted.
 
      set -eu
 
-     # Decompress vmlinuz into a temp file
+     echo "Updating decompressed kernel..."
+     [ -e /boot/firmware/vmlinux ] && \
+         cp /boot/firmware/vmlinux /boot/firmware/vmlinux.bak
      vmlinuxtmp=$(mktemp /boot/firmware/vmlinux.XXXXXXXX)
-     zcat -qf /boot/vmlinuz > $vmlinuxtmp
-
-     # If vmlinuz changed, move the temp file into place; otherwise, remove it.
-     if ! cmp --quiet $vmlinuxtmp /boot/firmware/vmlinux
-     then
-         echo "Updating decompressed kernel..."
-         [ -e /boot/firmware/vmlinux ] && \
-             cp /boot/firmware/vmlinux /boot/firmware/vmlinux.old
-         mv $vmlinuxtmp /boot/firmware/vmlinux
-         touch -r /boot/vmlinuz /boot/firmware/vmlinux
-     else
-         echo "No kernel decompression needed..."
-         rm $vmlinuxtmp
-     fi
+     zcat -qf /boot/vmlinuz > "$vmlinuxtmp"
+     mv "$vmlinuxtmp" /boot/firmware/vmlinux
      EOF
 
      chmod +x $MNT/root/etc/kernel/postinst.d/zz-decompress-kernel
-     umount $MNT/*
-     rm -fr $MNT
 
+   Cleanup::
+
+     umount $MNT/*
+     rm -rf $MNT
      exit
 
 #. Boot the Raspberry Pi.
 
-   Move the SD card into the Raspberry Pi. Boot it and login (e.g. via SSH)
+   Move the SD/USB disk to the Raspberry Pi. Boot it and login (e.g. via SSH)
    with ``ubuntu`` as the username and password.  If you are using SSH, note
    that it takes a little bit for cloud-init to enable password logins on the
    first boot.  Set a new password when prompted and login again using that
@@ -332,21 +325,21 @@ be deleted.
 Step 2: Setup ZFS
 -----------------
 
-#. Login as ``ubuntu``; then, become root::
+#. Become root::
 
      sudo -i
 
 #. Set the DISK and DISKP variables again::
 
-     DISK=/dev/mmcblk0    # SD card
-     DISKP=${DISK}p       # SD card
+     DISK=/dev/mmcblk0    # microSD card
+     DISKP=${DISK}p       # microSD card
 
      DISK=/dev/sdX        # USB disk
      DISKP=${DISK}        # USB disk
 
-   **WARNING:** Device names can change when moving a device to a different computer
-   or switching the SD card from a USB reader to a built-in slot. Double check the
-   device name before continuing.
+   **WARNING:** Device names can change when moving a device to a different
+   computer or switching the microSD card from a USB reader to a built-in
+   slot. Double check the device name before continuing.
 
 #. Install ZFS::
 
@@ -531,7 +524,7 @@ Step 3: System Installation
 
 #. Optional: Ignore synchronous requests:
 
-   SD cards are relatively slow.  If you want to increase performance
+   microSD cards are relatively slow.  If you want to increase performance
    (especially when installing packages) at the cost of some safety, you can
    disable flushing of synchronous requests (e.g. ``fsync()``, ``O_[D]SYNC``):
 
@@ -700,7 +693,7 @@ Step 4: System Configuration
      exit
      reboot
 
-   Wait for the newly installed system to boot normally.
+   Wait for the newly installed system to boot normally. Login as ``ubuntu``.
 
 Step 5: First Boot
 ------------------
@@ -709,13 +702,11 @@ Step 5: First Boot
 
      sudo -i
 
-#. Set the DISK and DISKP variables again::
+#. Set the DISK variable again::
 
-     DISK=/dev/mmcblk0    # SD card
-     DISKP=${DISK}p       # SD card
+     DISK=/dev/mmcblk0    # microSD card
 
      DISK=/dev/sdX        # USB disk
-     DISKP=${DISK}        # USB disk
 
 #. Delete the ext4 partition and expand the ZFS partition::
 
@@ -754,14 +745,6 @@ Step 5: First Boot
 
      sudo -i
 
-#. Set the DISK and DISKP variables again::
-
-     DISK=/dev/mmcblk0    # SD card
-     DISK=/dev/sdX        # USB disk
-
-     DISKP=${DISK}p       # SD card
-     DISKP=${DISK}        # USB disk
-
 #. Expand the ZFS pool:
 
    Verify the pool expanded::
@@ -769,6 +752,12 @@ Step 5: First Boot
      zfs list rpool
 
    If it did not automatically expand, try to expand it manually::
+
+     DISK=/dev/mmcblk0    # microSD card
+     DISKP=${DISK}p       # microSD card
+
+     DISK=/dev/sdX        # USB disk
+     DISKP=${DISK}        # USB disk
 
      zpool online -e rpool ${DISKP}2
 
@@ -781,13 +770,15 @@ Step 6: Full Software Installation
 
 #. Optional: Remove cloud-init::
 
-    cat >/etc/netplan/01-netcfg.yaml << EOF
-    network:
-      version: 2
-      ethernets:
-        eth0:
-          dhcp4: true
-    EOF
+    vi /etc/netplan/01-netcfg.yaml
+
+   .. code-block:: yaml
+
+     network:
+       version: 2
+       ethernets:
+         eth0:
+           dhcp4: true
 
     rm /etc/netplan/50-cloud-init.yaml
     apt purge --autoremove ^cloud-init

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
@@ -774,11 +774,11 @@ Step 6: Full Software Installation
 
    .. code-block:: yaml
 
-     network:
-       version: 2
-       ethernets:
-         eth0:
-           dhcp4: true
+    network:
+      version: 2
+      ethernets:
+        eth0:
+          dhcp4: true
 
     rm /etc/netplan/50-cloud-init.yaml
     apt purge --autoremove ^cloud-init

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
@@ -616,9 +616,9 @@ Step 4: System Configuration
 
 #. Setup system groups::
 
-     addgroup --system lpadmin
-     addgroup --system lxd
-     addgroup --system sambashare
+     addgroup --quiet --system lpadmin
+     addgroup --quiet --system lxd
+     addgroup --quiet --system sambashare
 
 #. Patch a dependency loop:
 


### PR DESCRIPTION
Modify the `Ubuntu 20.04 Root on ZFS for Raspberry Pi` instructions to allow installation on a USB SSD (or HDD, flash drive, etc.) To make the USB device bootable, the Linux image must be decompressed. Work by [James Chambers](https://jamesachambers.com/raspberry-pi-4-ubuntu-20-04-usb-mass-storage-boot-guide/) is incorporated to accomplish this. The three commits separate two set of ancillary changes from the main work.
