### PR TITLE
Use upstream sphinx-notfound-page module instead of fork

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,6 @@ jobs:
     - name: Gen_sphinx
       uses: ammaraskar/sphinx-action@master
       with:
-        pre-build-command: "apt-get update -y --allow-releaseinfo-change && apt-get install -y git"
         docs-folder: "docs/"
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,7 +19,6 @@ jobs:
     - name: Gen_sphinx
       uses: ammaraskar/sphinx-action@master
       with:
-        pre-build-command: "apt-get update -y --allow-releaseinfo-change && apt-get install -y git"
         docs-folder: "docs/"
     - uses: actions/upload-artifact@v2
       with:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -218,5 +218,4 @@ issues_pr_uri = "https://github.com/openzfs/zfs/pull/{pr}"
 issues_commit_uri = "https://github.com/openzfs/zfs/commit/{commit}"
 
 # Get absolute paths in 404
-notfound_no_urls_prefix = True
-notfound_url_prefix = '/openzfs-docs'
+notfound_urls_prefix = '/openzfs-docs/'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 Sphinx
 sphinx-issues
-# sphinx-notfound-page with change for Github Pages https://github.com/readthedocs/sphinx-notfound-page/pull/94
-git+https://github.com/gmelikov/sphinx-notfound-page.git@github_pages#egg=sphinx-notfound-page
+sphinx-notfound-page>=0.5
 sphinx-rtd-theme


### PR DESCRIPTION
We waited for changes to make 404s work properly
(absolute links with prefix).
It's in master now, use it.

Signed-off-by: George Melikov <mail@gmelikov.ru>