### PR TITLE
Use swapoff to ensure swap partitions are not mounted prior to clearing target disk

### DIFF
--- a/docs/Getting Started/Ubuntu/Ubuntu 16.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 16.04 Root on ZFS.rst
@@ -152,6 +152,9 @@ Step 2: Disk Formatting
 
 ::
 
+  Ensure swap paritions are not in use:
+  # swapoff --all
+
   If the disk was previously used in an MD array, zero the superblock:
   # apt install --yes mdadm
   # mdadm --zero-superblock --force /dev/disk/by-id/scsi-SATA_disk1

--- a/docs/Getting Started/Ubuntu/Ubuntu 18.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 18.04 Root on ZFS.rst
@@ -144,6 +144,10 @@ especially on systems that have more than one storage pool.
 
 2.2 If you are re-using a disk, clear it as necessary:
 
+Ensure swap partitions are not in use::
+
+  swapoff --all
+
 If the disk was previously used in an MD array, zero the superblock::
 
   apt install --yes mdadm

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
@@ -158,6 +158,10 @@ be deleted.
 
      DISK=/dev/mmcblk0
 
+#. Ensure swap partitions are not in use::
+
+     sudo swapoff --all
+
 #. Clear old ZFS labels::
 
      sudo zpool labelclear -f ${DISK}

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
@@ -291,6 +291,10 @@ Step 2: Disk Formatting
 
 #. If you are re-using a disk, clear it as necessary:
 
+   Ensure swap partitions are not in use::
+   
+     swapoff --all
+
    If the disk was previously used in an MD array::
 
      apt install --yes mdadm


### PR DESCRIPTION
In Step 1, use swapoff to ensure swap partitions are not mounted prior to clearing the target disk (e.g., 'sgdisk --zap-all').

Signed-off-by: Scott G. Ainsworth <scott@ainsworth.us>