### PR TITLE
Add more packages to the APT preference file

### DIFF
--- a/docs/Getting Started/Debian/index.rst
+++ b/docs/Getting Started/Debian/index.rst
@@ -32,7 +32,7 @@ Add the backports repository::
 
 .. code-block:: control
 
-  Package: libnvpair1linux libuutil1linux libzfs2linux libzpool2linux spl-dkms zfs-dkms zfs-test zfsutils-linux zfsutils-linux-dev zfs-zed
+  Package: libnvpair1linux libnvpair3linux libuutil1linux libuutil3linux libzfs2linux libzfs4linux libzpool2linux libzpool4linux spl-dkms zfs-dkms zfs-test zfsutils-linux zfsutils-linux-dev zfs-zed
   Pin: release n=buster-backports
   Pin-Priority: 990
 


### PR DESCRIPTION
When doing `apt upgrade` on my Debian machine, I saw that two packages was being held back. The reason cited was that the names had somewhat changed I think. It is worth noting that I'm running bullseye, so this might not be applicable to buster, which is the version documented here.