### PR TITLE
Correct UUID v4 generation for unique pool suffix

### DIFF
--- a/docs/Getting Started/Arch Linux/Root on ZFS/1-preparation.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS/1-preparation.rst
@@ -60,7 +60,7 @@ Preparation
    unique, therefore it's recommended to create
    pools with a unique suffix::
 
-    INST_UUID=$(dd if=/dev/urandom bs=1 count=100 2>/dev/null | tr -dc 'a-z0-9' | cut -c-6)
+    INST_UUID=$(xxd -l 16 -p /dev/random)
 
 #. Identify this installation in ZFS filesystem path::
 


### PR DESCRIPTION
Original example is wasteful and doesn't even produce a UUID as the variable name its result is assigned to would indicate- it uses the alphabet a-z0-9 and not a-f0-9.
Replacement produces an actual UUIDv4 (16 bytes or 32 hex chars), does it more directly, and uses random instead of urandom, which is more secure, and is unlikely to block in this case due to the more concise way it's computed.
While it introduces a new dependency, the xxd hexdump utility is present on every Arch install I've seen thus far.