### PR TITLE
GRUB: preliminary support for PBKDF2-only LUKS2

### DIFF
--- a/docs/Getting Started/Arch Linux/Root on ZFS/4-optional-configuration.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS/4-optional-configuration.rst
@@ -197,6 +197,7 @@ root pool will be replaced by keyfile, embedded in initrd.
 #. Let GRUB decrypt all LUKS containers on boot::
 
      tee -a /etc/grub.d/09_bpool_luks2-decryption <<FOE
+     #!/bin/sh
      cat <<EOF
        insmod luks2
        insmod pbkdf2

--- a/docs/Getting Started/Arch Linux/Root on ZFS/6-recovery.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS/6-recovery.rst
@@ -28,7 +28,7 @@ This section is also applicable if you are in
    Boot computer from the rescue media.
    Both legacy and EFI mode are supported.
 
-   Or `download generated GRUB rescue image <https://gitlab.com/m_zhou/bieaz/uploads/4a1b7cefb42723de6eb04f9dc485be3b/grub-rescue.img.7z>`__.
+   Or `download generated GRUB rescue image <https://nu8.org/pages/projects/bieaz/#grub-rescue-images>`__.
 
 #. List available disks with ``ls`` command::
 

--- a/docs/Getting Started/Fedora/Root on ZFS/6-recovery.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/6-recovery.rst
@@ -28,7 +28,7 @@ This section is also applicable if you are in
    Boot computer from the rescue media.
    Both legacy and EFI mode are supported.
 
-   Or `download generated GRUB rescue image <https://gitlab.com/m_zhou/bieaz/uploads/4a1b7cefb42723de6eb04f9dc485be3b/grub-rescue.img.7z>`__.
+   Or `download generated GRUB rescue image <https://nu8.org/pages/projects/bieaz/#grub-rescue-images>`__.
 
 #. List available disks with ``ls`` command::
 

--- a/docs/Getting Started/NixOS/Root on ZFS/1-preparation.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/1-preparation.rst
@@ -7,7 +7,7 @@ Preparation
    :local:
 
 #. Download `Minimal ISO image
-   <https://channels.nixos.org/nixos-21.05/latest-nixos-minimal-x86_64-linux.iso>`__ and boot from it.
+   <https://channels.nixos.org/nixos-21.11/latest-nixos-minimal-x86_64-linux.iso>`__ and boot from it.
 
 #. Connect to network. See `NixOS manual <https://nixos.org/manual/nixos/stable/index.html#sec-installation-booting>`__.
 

--- a/docs/Getting Started/NixOS/Root on ZFS/2-system-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/2-system-configuration.rst
@@ -339,8 +339,9 @@ System Configuration
         grub.zfsSupport = true;
         # for systemd-autofs
         grub.extraPrepareConfig = ''
-          mkdir -p /boot/efis
+          mkdir -p /boot/efis /boot/efi
           for i in  /boot/efis/*; do mount $i ; done
+          mount /boot/efi
         '';
         grub.extraInstallCommands = ''
            export ESP_MIRROR=$(mktemp -d -p /tmp)

--- a/docs/Getting Started/NixOS/Root on ZFS/2-system-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/2-system-configuration.rst
@@ -49,17 +49,7 @@ System Configuration
 
 
     zpool create \
-    -d -o feature@async_destroy=enabled \
-    -o feature@bookmarks=enabled \
-    -o feature@embedded_data=enabled \
-    -o feature@empty_bpobj=enabled \
-    -o feature@enabled_txg=enabled \
-    -o feature@extensible_dataset=enabled \
-    -o feature@filesystem_limits=enabled \
-    -o feature@hole_birth=enabled \
-    -o feature@large_blocks=enabled \
-    -o feature@lz4_compress=enabled \
-    -o feature@spacemap_histogram=enabled \
+        -o compatibility=grub2 \
         -o ashift=12 \
         -o autotrim=on \
         -O acltype=posixacl \

--- a/docs/Getting Started/NixOS/Root on ZFS/2-system-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/2-system-configuration.rst
@@ -212,8 +212,6 @@ System Configuration
         zfs create -o canmount=on -o mountpoint=/$i rpool_$INST_UUID/$INST_ID/DATA/local/$i
     done
 
-   Datasets for immutable root filesystem::
-
     zfs create -o canmount=on rpool_$INST_UUID/$INST_ID/DATA/default/state
     for i in {/etc/nixos,/etc/cryptkey.d}; do
       mkdir -p /mnt/state/$i /mnt/$i

--- a/docs/Getting Started/NixOS/Root on ZFS/3-optional-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/3-optional-configuration.rst
@@ -78,6 +78,7 @@ root pool will be replaced by keyfile, embedded in initrd.
     for i in ${DISK}; do
      umount /mnt/boot/efis/${i##*/}-part1
     done
+    umount /mnt/boot/efi
 
 #. Destroy boot pool::
 
@@ -159,6 +160,8 @@ root pool will be replaced by keyfile, embedded in initrd.
     for i in ${DISK}; do
      mount ${i}-part1 /mnt/boot/efis/${i##*/}-part1
     done
+
+    mount -t vfat ${INST_PRIMARY_DISK}-part1 /mnt/boot/efi
 
 #. As keys are stored in initrd,
    set secure permissions for ``/boot``::

--- a/docs/Getting Started/NixOS/Root on ZFS/4-system-installation.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/4-system-installation.rst
@@ -75,6 +75,7 @@ Finish installation
 #. Unmount EFI system partition::
 
     umount /mnt/boot/efis/*
+    umount /mnt/boot/efi
 
 #. Export pools::
 

--- a/docs/Getting Started/NixOS/Root on ZFS/6-recovery.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/6-recovery.rst
@@ -28,7 +28,7 @@ This section is also applicable if you are in
    Boot computer from the rescue media.
    Both legacy and EFI mode are supported.
 
-   Or `download generated GRUB rescue image <https://gitlab.com/m_zhou/bieaz/uploads/4a1b7cefb42723de6eb04f9dc485be3b/grub-rescue.img.7z>`__.
+   Or `download generated GRUB rescue image <https://nu8.org/pages/projects/bieaz/#grub-rescue-images>`__.
 
 #. List available disks with ``ls`` command::
 

--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/6-recovery.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/6-recovery.rst
@@ -28,7 +28,7 @@ This section is also applicable if you are in
    Boot computer from the rescue media.
    Both legacy and EFI mode are supported.
 
-   Or `download generated GRUB rescue image <https://gitlab.com/m_zhou/bieaz/uploads/4a1b7cefb42723de6eb04f9dc485be3b/grub-rescue.img.7z>`__.
+   Or `download generated GRUB rescue image <https://nu8.org/pages/projects/bieaz/#grub-rescue-images>`__.
 
 #. List available disks with ``ls`` command::
 


### PR DESCRIPTION
Affects: NixOS and Arch Linux Root on ZFS guides, encrypted boot pool section.

In GRUB 2.06, support for PBKDF2-only LUKS2 is introduced. Compared to LUKS1, currently used by the guides, LUKS2 offers a series of advantages. A list can be found on [development wiki](https://gitlab.com/cryptsetup/cryptsetup/-/wikis/FrequentlyAskedQuestions#10-luks2-questions)

Currently I have confirmed that, when `luks2 pdkf2 cryptodisk` modules are loaded, GRUB 2.06 can indeed open a PBKDF2-only LUKS2 container.

Whether `grub-mkconfig` can automatically detect LUKS2 container then insert necessary modules to `grub.cfg` during bootloader installation, is not tested.

Signed-off-by: Maurice Zhou <jasper@apvc.uk>