### PR TITLE
NixOS 21.11: always track the latest kernel compatible with ZFS

### DIFF
--- a/docs/Getting Started/NixOS/Root on ZFS/2-system-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/2-system-configuration.rst
@@ -273,6 +273,12 @@ System Configuration
     sed -i 's|fsType = "vfat";|fsType = "vfat"; options = [ "x-systemd.idle-timeout=1min" "x-systemd.automount" "noauto" ];|g' \
     /mnt/etc/nixos/hardware-configuration-zfs.nix
 
+   Restrict kernel to versions supported by ZFS::
+
+     tee -a /mnt/etc/nixos/${INST_CONFIG_FILE} <<EOF
+       boot.kernelPackages = config.boot.zfs.package.latestCompatibleLinuxPackages;
+     EOF
+
    Disable cache::
 
     mkdir -p /mnt/state/etc/zfs/


### PR DESCRIPTION
In NixOS 21.11, released on 30 Nov 2021, a new option has been added to force the system to use kernels compatible with ZFS.

This commit adds the option to the Root on ZFS guide.

@gmelikov 

Signed-off-by: Maurice Zhou <jasper@apvc.uk>