### PR TITLE
Add missing `cd`

### DIFF
--- a/docs/Getting Started/Arch Linux/Root on ZFS/4-optional-configuration.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS/4-optional-configuration.rst
@@ -25,6 +25,7 @@ for pacman integration::
   su - nobody -s /bin/bash
   mkdir /tmp/build
   export HOME=/tmp/build
+  cd
   git clone https://aur.archlinux.org/paru-bin.git
   cd paru-bin
   makepkg -si


### PR DESCRIPTION
When trying to execute this script, it fails because it doesn't move to the home directory. I think there's meant to be a `cd` after setting the `HOME` variable.