### PR TITLE
one liner install command does not work

### DIFF
--- a/docs/Getting Started/RHEL-based distro/index.rst
+++ b/docs/Getting Started/RHEL-based distro/index.rst
@@ -68,7 +68,8 @@ For RHEL/CentOS versions 6 and 7 run::
 
 And for RHEL/CentOS 8 and newer::
 
- dnf install epel-release kernel-devel zfs
+ dnf install epel-release
+ dnf install kernel-devel zfs
 
 .. note::
    When switching from DKMS to kABI-tracking kmods first uninstall the


### PR DESCRIPTION
the one-liner "dnf install epel-release kernel-devel zfs" does not work as intended, at least on RockyLinux 8.5. You need to break the line in 2 commands: one for epel and one for other two packages.