### PR TITLE
RHEL: switch to kmod

### DIFF
--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/1-preparation.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/1-preparation.rst
@@ -43,6 +43,8 @@ Preparation
 #. Install ZFS packages::
 
     dnf install -y epel-release
+    dnf config-manager --disable zfs
+    dnf config-manager --enable zfs-kmod
     dnf install -y zfs
 
 #. Load kernel modules::

--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/2-system-installation.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/2-system-installation.rst
@@ -244,6 +244,8 @@ System Installation
     ${RHEL_ZFS_REPO} @core epel-release grub2-efi-x64 grub2-pc-modules \
     grub2-efi-x64-modules shim-x64 efibootmgr \
     kernel kernel-devel python3-dnf-plugin-post-transaction-actions
+    dnf config-manager --installroot=/mnt --disable zfs
+    dnf config-manager --installroot=/mnt --enable zfs-kmod
     dnf install --installroot=/mnt -y zfs zfs-dracut
 
 #. Update zfs repo if a newer release is available::

--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/3-system-configuration.rst
@@ -94,10 +94,3 @@ System Configuration
 #. Set root password::
 
     passwd
-
-#. Build ZFS modules::
-
-    for directory in /lib/modules/*; do
-      kernel_version=$(basename $directory)
-      dkms autoinstall -k $kernel_version
-    done


### PR DESCRIPTION
Switch to kmod can save time and electricity from compilation. Currently, in order to perform a Rocky Linux Root on ZFS installation, DKMS package needs to be built for both live and installed system.

However, sometimes the latest version of kernel in Rocky repo might be incompatible with kmod package in zfsonlinux repo. In other words, zfsonlinux repo might lag behind official kernel releases, causing the installation to fail.

Request a review from @tonyhutter 

Signed-off-by: Maurice Zhou <jasper@apvc.uk>