### PR TITLE
Fedora: replace dnf remove with rpm -e --nodeps

### DIFF
--- a/docs/Getting Started/Fedora/Root on ZFS/1-preparation.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/1-preparation.rst
@@ -40,7 +40,7 @@ Preparation
 
 #. If zfs-fuse from official Fedora repo is installed, remove it first. It is not maintained and should not be used under any circumstance::
 
-    dnf remove -y zfs-fuse
+    rpm -e --nodeps zfs-fuse
 
 #. Install ZFS packages::
 

--- a/docs/Getting Started/Fedora/index.rst
+++ b/docs/Getting Started/Fedora/index.rst
@@ -20,7 +20,7 @@ see below.
    remove it first. It is not maintained and should not be used
    under any circumstance::
 
-    dnf remove -y zfs-fuse
+    rpm -e --nodeps zfs-fuse
 
 #. Add ZFS repo::
 


### PR DESCRIPTION
Fix an issue where removing zfs-fuse package will cause tons of other
packages marked for removal

Reported by @siepkes

Closes #245

@gmelikov Thanks for your diligent work on this repo and wish you a happy Christmas and new year!

Signed-off-by: Maurice Zhou <jasper@apvc.uk>