### PR TITLE
NixOS: remove unnecessary import service for LUKS bpool

### DIFF
--- a/docs/Getting Started/NixOS/Root on ZFS/3-optional-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/3-optional-configuration.rst
@@ -177,21 +177,6 @@ root pool will be replaced by keyfile, embedded in initrd.
     -o keyformat=raw \
     rpool_$INST_UUID/$INST_ID
 
-#. Import encrypted boot pool from ``/dev/mapper``::
-
-    tee -a /mnt/etc/nixos/${INST_CONFIG_FILE} <<-'EOF'
-      systemd.services.zfs-import-bpool-mapper = {
-        wantedBy = [ "zfs-import.target" ];
-        description = "Import encrypted boot pool";
-        after = [ "cryptsetup.target" ];
-        before = [ "boot.mount" ];
-        serviceConfig = {
-          Type = "oneshot";
-          ExecStart = ''${pkgs.zfs}/bin/zpool import -aNd /dev/mapper'';
-        };
-      };
-    EOF
-
 #. Enable GRUB cryptodisk::
 
     tee -a /mnt/etc/nixos/${INST_CONFIG_FILE} <<EOF


### PR DESCRIPTION
It has been discovered that, a separate systemd service is not only unnecessary for encrypted boot pool, it will even prevent the whole system from working properly due to introduced dependency cycles.

@gmelikov 

Signed-off-by: Maurice Zhou <jasper@apvc.uk>