### PR TITLE
zfs doc: upper bound for slop space calculation

### DIFF
--- a/docs/Performance and Tuning/Module Parameters.rst
+++ b/docs/Performance and Tuning/Module Parameters.rst
@@ -2013,6 +2013,7 @@ importing full pools on systems with larger spa_slop_shift can lead to
 over-full conditions.
 
 The minimum SPA slop space is limited to 128 MiB.
+The maximum SPA slop space is limited to 128 GiB.
 
 +-------------------+-------------------------------------------------+
 | spa_slop_shift    | Notes                                           |
@@ -2034,7 +2035,7 @@ The minimum SPA slop space is limited to 128 MiB.
 +-------------------+-------------------------------------------------+
 | Change            | Dynamic                                         |
 +-------------------+-------------------------------------------------+
-| Versions Affected | v0.6.5 and later                                |
+| Versions Affected | v0.6.5 and later (max. slop space since v2.1.0) |
 +-------------------+-------------------------------------------------+
 
 zfetch_array_rd_sz


### PR DESCRIPTION
OpenZFS v2.1 and above added an upper bound for slop space calculation.
See: https://github.com/openzfs/zfs/commit/f01eaed4556623b63c414fee9085ae27d457fe46