### PR TITLE
Use 'private' bind mounts

### DIFF
--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -584,9 +584,9 @@ Step 4: System Configuration
 #. Bind the virtual filesystems from the LiveCD environment to the new
    system and ``chroot`` into it::
 
-     mount --rbind /dev  /mnt/dev
-     mount --rbind /proc /mnt/proc
-     mount --rbind /sys  /mnt/sys
+     mount --make-private --rbind /dev  /mnt/dev
+     mount --make-private --rbind /proc /mnt/proc
+     mount --make-private --rbind /sys  /mnt/sys
      chroot /mnt /usr/bin/env DISK=$DISK bash --login
 
    **Note:** This is using ``--rbind``, not ``--bind``.
@@ -1095,9 +1095,9 @@ Mount everything correctly::
 
 If needed, you can chroot into your installed environment::
 
-  mount --rbind /dev  /mnt/dev
-  mount --rbind /proc /mnt/proc
-  mount --rbind /sys  /mnt/sys
+  mount --make-private --rbind /dev  /mnt/dev
+  mount --make-private --rbind /proc /mnt/proc
+  mount --make-private --rbind /sys  /mnt/sys
   mount -t tmpfs tmpfs /mnt/run
   mkdir /mnt/run/lock
   chroot /mnt /bin/bash --login

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
@@ -581,11 +581,11 @@ Step 4: System Configuration
 #. Bind the virtual filesystems from the running environment to the new
    ZFS environment and ``chroot`` into it::
 
-     mount --rbind /boot/firmware /mnt/boot/firmware
-     mount --rbind /dev  /mnt/dev
-     mount --rbind /proc /mnt/proc
-     mount --rbind /run  /mnt/run
-     mount --rbind /sys  /mnt/sys
+     mount --make-private --rbind /boot/firmware /mnt/boot/firmware
+     mount --make-private --rbind /dev  /mnt/dev
+     mount --make-private --rbind /proc /mnt/proc
+     mount --make-private --rbind /run  /mnt/run
+     mount --make-private --rbind /sys  /mnt/sys
      chroot /mnt /usr/bin/env DISK=$DISK UUID=$UUID bash --login
 
 #. Configure a basic system environment::

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
@@ -719,9 +719,9 @@ Step 4: System Configuration
 #. Bind the virtual filesystems from the LiveCD environment to the new
    system and ``chroot`` into it::
 
-     mount --rbind /dev  /mnt/dev
-     mount --rbind /proc /mnt/proc
-     mount --rbind /sys  /mnt/sys
+     mount --make-private --rbind /dev  /mnt/dev
+     mount --make-private --rbind /proc /mnt/proc
+     mount --make-private --rbind /sys  /mnt/sys
      chroot /mnt /usr/bin/env DISK=$DISK UUID=$UUID bash --login
 
    **Note:** This is using ``--rbind``, not ``--bind``.
@@ -1216,9 +1216,9 @@ Mount everything correctly::
 
 If needed, you can chroot into your installed environment::
 
-  mount --rbind /dev  /mnt/dev
-  mount --rbind /proc /mnt/proc
-  mount --rbind /sys  /mnt/sys
+  mount --make-private --rbind /dev  /mnt/dev
+  mount --make-private --rbind /proc /mnt/proc
+  mount --make-private --rbind /sys  /mnt/sys
   mount -t tmpfs tmpfs /mnt/run
   mkdir /mnt/run/lock
   chroot /mnt /bin/bash --login

--- a/docs/Getting Started/openSUSE/openSUSE Leap Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Leap Root on ZFS.rst
@@ -624,9 +624,9 @@ Step 5: System Configuration
 #. Bind the virtual filesystems from the LiveCD environment to the new
    system and ``chroot`` into it::
 
-     mount --rbind /dev  /mnt/dev
-     mount --rbind /proc /mnt/proc
-     mount --rbind /sys  /mnt/sys
+     mount --make-private --rbind /dev  /mnt/dev
+     mount --make-private --rbind /proc /mnt/proc
+     mount --make-private --rbind /sys  /mnt/sys
      mount -t tmpfs tmpfs /mnt/run
      mkdir /mnt/run/lock
 
@@ -1152,9 +1152,9 @@ Mount everything correctly::
 
 If needed, you can chroot into your installed environment::
 
-  mount --rbind /dev  /mnt/dev
-  mount --rbind /proc /mnt/proc
-  mount --rbind /sys  /mnt/sys
+  mount --make-private --rbind /dev  /mnt/dev
+  mount --make-private --rbind /proc /mnt/proc
+  mount --make-private --rbind /sys  /mnt/sys
   chroot /mnt /bin/bash --login
   mount /boot
   mount -a

--- a/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
@@ -624,9 +624,9 @@ Step 5: System Configuration
 #. Bind the virtual filesystems from the LiveCD environment to the new
    system and ``chroot`` into it::
 
-     mount --rbind /dev  /mnt/dev
-     mount --rbind /proc /mnt/proc
-     mount --rbind /sys  /mnt/sys
+     mount --make-private --rbind /dev  /mnt/dev
+     mount --make-private --rbind /proc /mnt/proc
+     mount --make-private --rbind /sys  /mnt/sys
      mount -t tmpfs tmpfs /mnt/run
      mkdir /mnt/run/lock
 
@@ -1152,9 +1152,9 @@ Mount everything correctly::
 
 If needed, you can chroot into your installed environment::
 
-  mount --rbind /dev  /mnt/dev
-  mount --rbind /proc /mnt/proc
-  mount --rbind /sys  /mnt/sys
+  mount --make-private --rbind /dev  /mnt/dev
+  mount --make-private --rbind /proc /mnt/proc
+  mount --make-private --rbind /sys  /mnt/sys
   chroot /mnt /bin/bash --login
   mount /boot
   mount -a


### PR DESCRIPTION
When plain '--rbind' is used, the 'umount' process executed later in the
setup process completely unmounts the bound filesystem, resulting in various
forms of breakage on the host used to do the setup. When a Live CD is used
and the system will be immediately shutdown/rebooted, this isn't an issue,
but in other scenarios it can be problematic.

Making the bind mounts 'private' avoids this problem. This patch changes
the setup guides for 'modern' distribution versions but does not touch
the older ones where this functionality may not be available.

Signed-off-by: Kevin P. Fleming <kevin@km6g.us>

CC: @rlaager 