### PR TITLE
Arch Linux: Update LiveISO. 2022.01.01

### DIFF
--- a/docs/Getting Started/Arch Linux/Root on ZFS/1-preparation.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS/1-preparation.rst
@@ -7,8 +7,8 @@ Preparation
    :local:
 
 #. Download
-   `2021.11.01 <https://mirrors.ocf.berkeley.edu/archlinux/iso/2021.11.01/archlinux-2021.11.01-x86_64.iso>`__
-   Live ISO and `signature <https://archlinux.org/iso/2021.11.01/archlinux-2021.11.01-x86_64.iso.sig>`__.
+   `2022.01.01 <https://mirrors.ocf.berkeley.edu/archlinux/iso/2022.01.01/archlinux-2022.01.01-x86_64.iso>`__
+   Live ISO and `signature <https://archlinux.org/iso/2022.01.01/archlinux-2022.01.01-x86_64.iso.sig>`__.
 
 #. Follow `installation guide on Arch wiki <https://wiki.archlinux.org/title/Installation_guide>`__
    up to **Update the system clock**.

--- a/docs/Getting Started/Arch Linux/Root on ZFS/4-optional-configuration.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS/4-optional-configuration.rst
@@ -284,9 +284,9 @@ boot from it. This enables system recovery and re-installation.
 
     mkdir /boot/efi/iso
     cd /boot/efi/iso
-    # select a mirror # curl -O https://mirrors.ocf.berkeley.edu/archlinux/iso/2021.11.01/archlinux-2021.11.01-x86_64.iso
-    curl -O https://archlinux.org/iso/2021.11.01/archlinux-2021.11.01-x86_64.iso.sig
-    gpg --auto-key-retrieve --verify archlinux-2021.11.01-x86_64.iso.sig
+    # select a mirror # curl -O https://mirrors.ocf.berkeley.edu/archlinux/iso/2022.01.01/archlinux-2022.01.01-x86_64.iso
+    curl -O https://archlinux.org/iso/2022.01.01/archlinux-2022.01.01-x86_64.iso.sig
+    gpg --auto-key-retrieve --verify archlinux-2022.01.01-x86_64.iso.sig
 
    Additionally you can build your own live image
    with `archiso package <https://gitlab.archlinux.org/archlinux/archiso>`__.


### PR DESCRIPTION
2022.01.01: linux 5.15.12
zfs: 2.1.2; supported

@gmelikov We need to either automate updating live iso links or find another people as collaborator: I might not be around to update this link.

The procedure is documented [here](https://openzfs.github.io/openzfs-docs/Getting%20Started/Arch%20Linux/3-live.html).

Signed-off-by: Maurice Zhou <jasper@apvc.uk>