### PR TITLE
Patching zfs-mount-generator no longer required.

### DIFF
--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
@@ -119,10 +119,7 @@ installed, you should switch to encrypted swap::
   sudo vi /etc/fstab
   # Remove the swap entry.
 
-  sudo apt install --yes cryptsetup curl patch
-
-  curl https://launchpadlibrarian.net/478315221/2150-fix-systemd-dependency-loops.patch | \
-      sed "s|/etc|/lib|;s|\.in$||" | (cd / ; sudo patch -p1)
+  sudo apt install --yes cryptsetup
 
   # Replace DISK-partN as appropriate from above:
   echo swap /dev/disk/by-id/DISK-partN /dev/urandom \


### PR DESCRIPTION
The patch has been brought into Ubuntu 20.04 and is no longer needed in this guide.