### PR TITLE
Fix bug: dracut config must not be overwritten

### DIFF
--- a/docs/Getting Started/Fedora/Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/3-system-configuration.rst
@@ -33,8 +33,8 @@ System Configuration
 
 #. Force load mpt3sas module if used::
 
-     if grep -q mpt3sas /proc/modules; then
-       echo 'forced_drivers+=" mpt3sas "'  > /mnt/etc/dracut.conf.d/zfs.conf
+     if grep mpt3sas /proc/modules; then
+       echo 'forced_drivers+=" mpt3sas "'  >> /mnt/etc/dracut.conf.d/zfs.conf
      fi
 
 #. Enable timezone sync::

--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/3-system-configuration.rst
@@ -33,8 +33,8 @@ System Configuration
 
 #. Force load mpt3sas module if used::
 
-     if grep -q mpt3sas /proc/modules; then
-       echo 'forced_drivers+=" mpt3sas "'  > /mnt/etc/dracut.conf.d/zfs.conf
+     if grep mpt3sas /proc/modules; then
+       echo 'forced_drivers+=" mpt3sas "'  >> /mnt/etc/dracut.conf.d/zfs.conf
      fi
 
 #. Interactively set locale, keymap, timezone, hostname and root password::


### PR DESCRIPTION
Previous commit introduced a bug where dracut config was overwritten during system configuration.

@gmelikov

Signed-off-by: Maurice Zhou <jasper@apvc.uk>