### PR TITLE
bugfix/attribute 'efi' already defined error.

### DIFF
--- a/docs/Getting Started/NixOS/Root on ZFS/2-system-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/2-system-configuration.rst
@@ -319,13 +319,14 @@ System Configuration
 
     sed -i '/boot.loader/d' /mnt/etc/nixos/configuration.nix
     tee -a /mnt/etc/nixos/${INST_CONFIG_FILE} <<-'EOF'
+      boot.loader.efi.canTouchEfiVariables = false;
+      ##if UEFI firmware can detect entries
+      #boot.loader.efi.canTouchEfiVariables = true;
+
       boot.loader = {
         generationsDir.copyKernels = true;
         ##for problematic UEFI firmware
         grub.efiInstallAsRemovable = true;
-        efi.canTouchEfiVariables = false;
-        ##if UEFI firmware can detect entries
-        #efi.canTouchEfiVariables = true;
         grub.enable = true;
         grub.version = 2;
         grub.copyKernels = true;


### PR DESCRIPTION
When attempting to run the scripts as defined in the documentation, an error is generated `error: attribute 'efi' already defined at system-configuration.nix`. The issue is that `boot.loader.efi` was already defined as:
```bash
boot.loader.efi.efiSysMountPoint = "/boot/efis/${INST_PRIMARY_DISK##*/}-part1";
```
as seen in Step 12 of System Configuration. And then redefined in Step 13:
```bash
boot.loader = {
    generationsDir.copyKernels = true;
    ##for problematic UEFI firmware
    grub.efiInstallAsRemovable = true;
    efi.canTouchEfiVariables = false;
    ##if UEFI firmware can detect entries
    #efi.canTouchEfiVariables = true;
...
```
This causes Nix to throw an error saying `efi` is already defined.

I've created a minimal working example to show the problem. Download the [boot-loader.txt](https://github.com/openzfs/openzfs-docs/files/8383261/boot-loader.txt) and run `nix-instantiate --eval --strict boot-loader.txt` and you should get something similar to
```sh
error: attribute 'efi' already defined at /PATH/boot-loader.txt:6:5

       at /PATH/boot-loader.txt:2:3:

            1| let
            2|   boot.loader.efi.efiSysMountDisk = "/boot/efis/nvme----";
             |   ^
            3|   # boot.loader.efi.canTouchEfiVariables = true;
```