### PR TITLE
bugfix/removing unnecessary efi mount/umount commands

### DIFF
--- a/docs/Getting Started/NixOS/Root on ZFS/2-system-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/2-system-configuration.rst
@@ -333,9 +333,8 @@ System Configuration
         grub.zfsSupport = true;
         # for systemd-autofs
         grub.extraPrepareConfig = ''
-          mkdir -p /boot/efis /boot/efi
+          mkdir -p /boot/efis
           for i in  /boot/efis/*; do mount $i ; done
-          mount /boot/efi
         '';
         grub.extraInstallCommands = ''
            export ESP_MIRROR=$(mktemp -d -p /tmp)

--- a/docs/Getting Started/NixOS/Root on ZFS/3-optional-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/3-optional-configuration.rst
@@ -78,7 +78,6 @@ root pool will be replaced by keyfile, embedded in initrd.
     for i in ${DISK}; do
      umount /mnt/boot/efis/${i##*/}-part1
     done
-    umount /mnt/boot/efi
 
 #. Destroy boot pool::
 
@@ -160,8 +159,6 @@ root pool will be replaced by keyfile, embedded in initrd.
     for i in ${DISK}; do
      mount ${i}-part1 /mnt/boot/efis/${i##*/}-part1
     done
-
-    mount -t vfat ${INST_PRIMARY_DISK}-part1 /mnt/boot/efi
 
 #. As keys are stored in initrd,
    set secure permissions for ``/boot``::

--- a/docs/Getting Started/NixOS/Root on ZFS/4-system-installation.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/4-system-installation.rst
@@ -86,7 +86,6 @@ Finish installation
 #. Unmount EFI system partition::
 
     umount /mnt/boot/efis/*
-    umount /mnt/boot/efi
 
 #. Export pools::
 


### PR DESCRIPTION
This fixes an issue where the OS would through an error during the system installation. There was a `umount` call that didn't unmount anything and would produce an error as shown:
```sh
$ umount /mnt/boot/efi
umount: /mnt/boot/efi: no mount point specified
```

There were also lines in the zfs.nix file under `grub.extraPrepareConfig` that were removed because `/boot/efi` is not used but `/boot/efis` is.

<strike>
This fixes an issue where the file system was not unmounted completely before exporting the zpools.

There was a `umount` call previously that didn't unmount anything and would produce an error as shown:
```sh
$ umount /mnt/boot/efi
umount: /mnt/boot/efi: no mount point specified
```

Additionally, the newly created zpools were not completely unmounted and would cause them to not be imported properly after reboot. I believe this is related to #270 as the symptoms are very similar, but I cannot confirm as I have not tried the same installation.
</strike>