### PR TITLE
Added --new-install to tasksel in Debian * Root on ZFS

### DIFF
--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -1008,7 +1008,7 @@ Step 8: Full Software Installation
 
 #. Install a regular set of software::
 
-     tasksel
+     tasksel --new-install
 
 #. Optional: Disable log compression:
 

--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -986,7 +986,7 @@ Step 8: Full Software Installation
 
 #. Install a regular set of software::
 
-     tasksel
+     tasksel --new-install
 
 #. Optional: Disable log compression:
 

--- a/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
@@ -898,7 +898,7 @@ Step 8: Full Software Installation
 
 ::
 
-  # tasksel
+  # tasksel --new-install
 
 8.3 Optional: Disable log compression:
 


### PR DESCRIPTION
@rlaager In the install instructions for Debian with a ZFS root, it might be advisable to add the --new-install switch to tasksel, upon step 8 "full software installation". As far as I understand it, this switch makes tasksel include the "standard system utilities" task, which is supposed to be installed, and would otherwise be skipped.