### PR TITLE
added mkdir /etc/dropbear-initramfs

### DIFF
--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -737,6 +737,7 @@ Step 4: System Configuration
      apt install --yes --no-install-recommends dropbear-initramfs
 
      # Optional: Convert OpenSSH server keys for Dropbear
+     mkdir /etc/dropbear-initramfs
      for type in ecdsa ed25519 rsa ; do
          cp /etc/ssh/ssh_host_${type}_key /tmp/openssh.key
          ssh-keygen -p -N "" -m PEM -f /tmp/openssh.key


### PR DESCRIPTION
/etc/dropbear-initramfs is not create automatically with: apt install --yes --no-install-recommends dropbear-initramfs
- at least on Debian Testing ;)