### PR TITLE
Update index.rst - typo in example command line

### DIFF
--- a/docs/Getting Started/RHEL-based distro/index.rst
+++ b/docs/Getting Started/RHEL-based distro/index.rst
@@ -38,7 +38,7 @@ the fingerprint listed here.
 
 For RHEL/CentOS versions 6 and 7 run::
 
- yum install https://zfsonlinux.org/epel/zfs-release$(rpm -E %distro).noarch.rpm
+ yum install https://zfsonlinux.org/epel/zfs-release$(rpm -E %dist).noarch.rpm
  rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux
 
 And for RHEL 8.5::


### PR DESCRIPTION
Commandline "yum install https://zfsonlinux.org/epel/zfs-release$(rpm -E %dist).noarch.rpm" had typo, to use "%distro" rather "%dist"

[root]# rpm -E %distro
%distro
[root]# rpm -E %dist
.el7_9