### PR TITLE
do *not* enforce UTF-8

### DIFF
--- a/docs/Getting Started/Arch Linux/Root on ZFS/2-system-installation.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS/2-system-installation.rst
@@ -54,7 +54,6 @@ System Installation
         -O canmount=off \
         -O compression=lz4 \
         -O devices=off \
-        -O normalization=formD \
         -O relatime=on \
         -O xattr=sa \
         -O mountpoint=/boot \
@@ -87,7 +86,6 @@ System Installation
            -O canmount=off \
            -O compression=zstd \
            -O dnodesize=auto \
-           -O normalization=formD \
            -O relatime=on \
            -O xattr=sa \
            -O mountpoint=/ \
@@ -116,6 +114,8 @@ System Installation
      of why requiring UTF-8 filenames may be a bad idea, see `The problems
      with enforced UTF-8 only filenames
      <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
+     A previous version of this guide suggested this setting, but it was 
+     reverted because of those problems.
    - ``recordsize`` is unset (leaving it at the default of 128 KiB). If you
      want to tune it (e.g. ``-o recordsize=1M``), see `these
      <https://jrs-s.net/2019/04/03/on-zfs-recordsize/>`__ `various

--- a/docs/Getting Started/Arch Linux/Root on ZFS/4-optional-configuration.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS/4-optional-configuration.rst
@@ -145,7 +145,6 @@ root pool will be replaced by keyfile, embedded in initrd.
         -O canmount=off \
         -O compression=lz4 \
         -O devices=off \
-        -O normalization=formD \
         -O relatime=on \
         -O xattr=sa \
         -O mountpoint=/boot \

--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -242,7 +242,7 @@ Step 2: Disk Formatting
          -o feature@spacemap_histogram=enabled \
          -o feature@zpool_checkpoint=enabled \
          -O acltype=posixacl -O canmount=off -O compression=lz4 \
-         -O devices=off -O normalization=formD -O relatime=on -O xattr=sa \
+         -O devices=off -O relatime=on -O xattr=sa \
          -O mountpoint=/boot -R /mnt \
          bpool ${DISK}-part3
 
@@ -304,7 +304,7 @@ Step 2: Disk Formatting
        zpool create \
            -o ashift=12 \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool ${DISK}-part4
 
@@ -315,7 +315,7 @@ Step 2: Disk Formatting
            -O encryption=aes-256-gcm \
            -O keylocation=prompt -O keyformat=passphrase \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool ${DISK}-part4
 
@@ -328,7 +328,7 @@ Step 2: Disk Formatting
        zpool create \
            -o ashift=12 \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool /dev/mapper/luks1
 
@@ -344,13 +344,6 @@ Step 2: Disk Formatting
      ``-o acltype=posixacl`` (note: lowercase “o”) to the ``zfs create``
      for ``/var/log``, as `journald requires ACLs
      <https://askubuntu.com/questions/970886/journalctl-says-failed-to-search-journal-acl-operation-not-supported>`__
-   - Setting ``normalization=formD`` eliminates some corner cases relating
-     to UTF-8 filename normalization. It also implies ``utf8only=on``,
-     which means that only UTF-8 filenames are allowed. If you care to
-     support non-UTF-8 filenames, do not use this option. For a discussion
-     of why requiring UTF-8 filenames may be a bad idea, see `The problems
-     with enforced UTF-8 only filenames
-     <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
    - ``recordsize`` is unset (leaving it at the default of 128 KiB). If you
      want to tune it (e.g. ``-o recordsize=1M``), see `these
      <https://jrs-s.net/2019/04/03/on-zfs-recordsize/>`__ `various
@@ -414,6 +407,15 @@ Step 2: Disk Formatting
    - The pool name is arbitrary. If changed, the new name must be used
      consistently. On systems that can automatically install to ZFS, the root
      pool is named ``rpool`` by default.
+   - Setting ``normalization=formD`` eliminates some corner cases relating
+     to UTF-8 filename normalization. It also implies ``utf8only=on``,
+     which means that only UTF-8 filenames are allowed. If you care to
+     support non-UTF-8 filenames, do not use this option. For a discussion
+     of why requiring UTF-8 filenames may be a bad idea, see `The problems
+     with enforced UTF-8 only filenames
+     <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
+     A previous version of this guide suggested this setting, but it was 
+     reverted because of those problems.
 
 Step 3: System Installation
 ---------------------------

--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -256,7 +256,7 @@ Step 2: Disk Formatting
          -o feature@spacemap_histogram=enabled \
          -o feature@zpool_checkpoint=enabled \
          -O acltype=posixacl -O canmount=off -O compression=lz4 \
-         -O devices=off -O normalization=formD -O relatime=on -O xattr=sa \
+         -O devices=off -O relatime=on -O xattr=sa \
          -O mountpoint=/boot -R /mnt \
          bpool ${DISK}-part3
 
@@ -314,7 +314,7 @@ Step 2: Disk Formatting
        zpool create \
            -o ashift=12 \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool ${DISK}-part4
 
@@ -325,7 +325,7 @@ Step 2: Disk Formatting
            -O encryption=aes-256-gcm \
            -O keylocation=prompt -O keyformat=passphrase \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool ${DISK}-part4
 
@@ -338,7 +338,7 @@ Step 2: Disk Formatting
        zpool create \
            -o ashift=12 \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool /dev/mapper/luks1
 
@@ -354,13 +354,6 @@ Step 2: Disk Formatting
      ``-o acltype=posixacl`` (note: lowercase “o”) to the ``zfs create``
      for ``/var/log``, as `journald requires ACLs
      <https://askubuntu.com/questions/970886/journalctl-says-failed-to-search-journal-acl-operation-not-supported>`__
-   - Setting ``normalization=formD`` eliminates some corner cases relating
-     to UTF-8 filename normalization. It also implies ``utf8only=on``,
-     which means that only UTF-8 filenames are allowed. If you care to
-     support non-UTF-8 filenames, do not use this option. For a discussion
-     of why requiring UTF-8 filenames may be a bad idea, see `The problems
-     with enforced UTF-8 only filenames
-     <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
    - ``recordsize`` is unset (leaving it at the default of 128 KiB). If you
      want to tune it (e.g. ``-o recordsize=1M``), see `these
      <https://jrs-s.net/2019/04/03/on-zfs-recordsize/>`__ `various
@@ -424,6 +417,15 @@ Step 2: Disk Formatting
    - The pool name is arbitrary. If changed, the new name must be used
      consistently. On systems that can automatically install to ZFS, the root
      pool is named ``rpool`` by default.
+   - Setting ``normalization=formD`` eliminates some corner cases relating
+     to UTF-8 filename normalization. It also implies ``utf8only=on``,
+     which means that only UTF-8 filenames are allowed. If you care to
+     support non-UTF-8 filenames, do not use this option. For a discussion
+     of why requiring UTF-8 filenames may be a bad idea, see `The problems
+     with enforced UTF-8 only filenames
+     <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
+     A previous version of this guide suggested this setting, but it was 
+     reverted because of those problems.
 
 Step 3: System Installation
 ---------------------------

--- a/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
@@ -211,7 +211,7 @@ especially on systems that have more than one storage pool.
         -o feature@spacemap_histogram=enabled \
         -o feature@userobj_accounting=enabled \
         -O acltype=posixacl -O canmount=off -O compression=lz4 -O devices=off \
-        -O normalization=formD -O relatime=on -O xattr=sa \
+        -O relatime=on -O xattr=sa \
         -O mountpoint=/ -R /mnt \
         bpool /dev/disk/by-id/scsi-SATA_disk1-part3
 
@@ -244,7 +244,7 @@ Choose one of the following options:
 
   # zpool create -o ashift=12 \
         -O acltype=posixacl -O canmount=off -O compression=lz4 \
-        -O dnodesize=auto -O normalization=formD -O relatime=on -O xattr=sa \
+        -O dnodesize=auto -O relatime=on -O xattr=sa \
         -O mountpoint=/ -R /mnt \
         rpool /dev/disk/by-id/scsi-SATA_disk1-part4
 
@@ -258,7 +258,7 @@ Choose one of the following options:
   # cryptsetup luksOpen /dev/disk/by-id/scsi-SATA_disk1-part4 luks1
   # zpool create -o ashift=12 \
         -O acltype=posixacl -O canmount=off -O compression=lz4 \
-        -O dnodesize=auto -O normalization=formD -O relatime=on -O xattr=sa \
+        -O dnodesize=auto -O relatime=on -O xattr=sa \
         -O mountpoint=/ -R /mnt \
         rpool /dev/mapper/luks1
 
@@ -272,13 +272,6 @@ Choose one of the following options:
   ``-o acltype=posixacl`` (note: lowercase "o") to the ``zfs create``
   for ``/var/log``, as `journald requires
   ACLs <https://askubuntu.com/questions/970886/journalctl-says-failed-to-search-journal-acl-operation-not-supported>`__
-- Setting ``normalization=formD`` eliminates some corner cases relating
-  to UTF-8 filename normalization. It also implies ``utf8only=on``,
-  which means that only UTF-8 filenames are allowed. If you care to
-  support non-UTF-8 filenames, do not use this option. For a discussion
-  of why requiring UTF-8 filenames may be a bad idea, see `The problems
-  with enforced UTF-8 only
-  filenames <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
 - Setting ``relatime=on`` is a middle ground between classic POSIX
   ``atime`` behavior (with its significant performance impact) and
   ``atime=off`` (which provides the best performance by completely
@@ -325,6 +318,15 @@ Choose one of the following options:
 - The pool name is arbitrary. If changed, the new name must be used
   consistently. On systems that can automatically install to ZFS, the
   root pool is named ``rpool`` by default.
+- Setting ``normalization=formD`` eliminates some corner cases relating
+  to UTF-8 filename normalization. It also implies ``utf8only=on``,
+  which means that only UTF-8 filenames are allowed. If you care to
+  support non-UTF-8 filenames, do not use this option. For a discussion
+  of why requiring UTF-8 filenames may be a bad idea, see `The problems
+  with enforced UTF-8 only
+  filenames <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
+  A previous version of this guide suggested this setting, but it was 
+  reverted because of those problems.
 
 Step 3: System Installation
 ---------------------------

--- a/docs/Getting Started/Fedora/Root on ZFS/2-system-installation.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/2-system-installation.rst
@@ -56,7 +56,6 @@ System Installation
         -O canmount=off \
         -O compression=lz4 \
         -O devices=off \
-        -O normalization=formD \
         -O relatime=on \
         -O xattr=sa \
         -O mountpoint=/boot \
@@ -89,7 +88,6 @@ System Installation
            -O canmount=off \
            -O compression=zstd \
            -O dnodesize=auto \
-           -O normalization=formD \
            -O relatime=on \
            -O xattr=sa \
            -O mountpoint=/ \
@@ -118,6 +116,8 @@ System Installation
      of why requiring UTF-8 filenames may be a bad idea, see `The problems
      with enforced UTF-8 only filenames
      <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
+     A previous version of this guide suggested this setting, but it was 
+     reverted because of those problems.
    - ``recordsize`` is unset (leaving it at the default of 128 KiB). If you
      want to tune it (e.g. ``-o recordsize=1M``), see `these
      <https://jrs-s.net/2019/04/03/on-zfs-recordsize/>`__ `various

--- a/docs/Getting Started/NixOS/Root on ZFS/2-system-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/2-system-configuration.rst
@@ -56,7 +56,6 @@ System Configuration
         -O canmount=off \
         -O compression=lz4 \
         -O devices=off \
-        -O normalization=formD \
         -O relatime=on \
         -O xattr=sa \
         -O mountpoint=/boot \
@@ -89,7 +88,6 @@ System Configuration
            -O canmount=off \
            -O compression=zstd \
            -O dnodesize=auto \
-           -O normalization=formD \
            -O relatime=on \
            -O xattr=sa \
            -O mountpoint=/ \
@@ -118,6 +116,8 @@ System Configuration
      of why requiring UTF-8 filenames may be a bad idea, see `The problems
      with enforced UTF-8 only filenames
      <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
+     A previous version of this guide suggested this setting, but it was 
+     reverted because of those problems.
    - ``recordsize`` is unset (leaving it at the default of 128 KiB). If you
      want to tune it (e.g. ``-o recordsize=1M``), see `these
      <https://jrs-s.net/2019/04/03/on-zfs-recordsize/>`__ `various

--- a/docs/Getting Started/NixOS/Root on ZFS/3-optional-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/3-optional-configuration.rst
@@ -136,7 +136,6 @@ root pool will be replaced by keyfile, embedded in initrd.
         -O canmount=off \
         -O compression=lz4 \
         -O devices=off \
-        -O normalization=formD \
         -O relatime=on \
         -O xattr=sa \
         -O mountpoint=/boot \

--- a/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/2-system-installation.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL 8-based distro Root on ZFS/2-system-installation.rst
@@ -66,7 +66,6 @@ System Installation
         -O canmount=off \
         -O compression=lz4 \
         -O devices=off \
-        -O normalization=formD \
         -O relatime=on \
         -O xattr=sa \
         -O mountpoint=/boot \
@@ -99,7 +98,6 @@ System Installation
            -O canmount=off \
            -O compression=zstd \
            -O dnodesize=auto \
-           -O normalization=formD \
            -O relatime=on \
            -O xattr=sa \
            -O mountpoint=/ \
@@ -128,6 +126,8 @@ System Installation
      of why requiring UTF-8 filenames may be a bad idea, see `The problems
      with enforced UTF-8 only filenames
      <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
+     A previous version of this guide suggested this setting, but it was 
+     reverted because of those problems.
    - ``recordsize`` is unset (leaving it at the default of 128 KiB). If you
      want to tune it (e.g. ``-o recordsize=1M``), see `these
      <https://jrs-s.net/2019/04/03/on-zfs-recordsize/>`__ `various

--- a/docs/Getting Started/Ubuntu/Ubuntu 18.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 18.04 Root on ZFS.rst
@@ -201,7 +201,7 @@ commands for all the disks which will be part of the pool.
       -o feature@lz4_compress=enabled \
       -o feature@spacemap_histogram=enabled \
       -O acltype=posixacl -O canmount=off -O compression=lz4 -O devices=off \
-      -O normalization=formD -O relatime=on -O xattr=sa \
+      -O relatime=on -O xattr=sa \
       -O mountpoint=/ -R /mnt bpool ${DISK}-part3
 
 You should not need to customize any of the options for the boot pool.
@@ -237,7 +237,7 @@ Choose one of the following options:
 
   zpool create -o ashift=12 \
       -O acltype=posixacl -O canmount=off -O compression=lz4 \
-      -O dnodesize=auto -O normalization=formD -O relatime=on -O xattr=sa \
+      -O dnodesize=auto -O relatime=on -O xattr=sa \
       -O mountpoint=/ -R /mnt rpool ${DISK}-part4
 
 2.5b LUKS::
@@ -246,7 +246,7 @@ Choose one of the following options:
   cryptsetup luksOpen ${DISK}-part4 luks1
   zpool create -o ashift=12 \
       -O acltype=posixacl -O canmount=off -O compression=lz4 \
-      -O dnodesize=auto -O normalization=formD -O relatime=on -O xattr=sa \
+      -O dnodesize=auto -O relatime=on -O xattr=sa \
       -O mountpoint=/ -R /mnt rpool /dev/mapper/luks1
 
 **Notes:**
@@ -261,13 +261,6 @@ Choose one of the following options:
   ``-o acltype=posixacl`` (note: lowercase “o”) to the ``zfs create``
   for ``/var/log``, as `journald requires
   ACLs <https://askubuntu.com/questions/970886/journalctl-says-failed-to-search-journal-acl-operation-not-supported>`__
-- Setting ``normalization=formD`` eliminates some corner cases relating
-  to UTF-8 filename normalization. It also implies ``utf8only=on``,
-  which means that only UTF-8 filenames are allowed. If you care to
-  support non-UTF-8 filenames, do not use this option. For a discussion
-  of why requiring UTF-8 filenames may be a bad idea, see `The problems
-  with enforced UTF-8 only
-  filenames <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
 - ``recordsize`` is unset (leaving it at the default of 128 KiB). If you want to
   tune it (e.g. ``-o recordsize=1M``), see `these
   <https://jrs-s.net/2019/04/03/on-zfs-recordsize/>`__ `various
@@ -321,6 +314,15 @@ Choose one of the following options:
 - The pool name is arbitrary. If changed, the new name must be used
   consistently. On systems that can automatically install to ZFS, the
   root pool is named ``rpool`` by default.
+- Setting ``normalization=formD`` eliminates some corner cases relating
+  to UTF-8 filename normalization. It also implies ``utf8only=on``,
+  which means that only UTF-8 filenames are allowed. If you care to
+  support non-UTF-8 filenames, do not use this option. For a discussion
+  of why requiring UTF-8 filenames may be a bad idea, see `The problems
+  with enforced UTF-8 only
+  filenames <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
+  A previous version of this guide suggested this setting, but it was 
+  reverted because of those problems.
 
 Step 3: System Installation
 ---------------------------

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
@@ -371,7 +371,7 @@ Step 2: Setup ZFS
        zpool create \
            -o ashift=12 \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool ${DISKP}2
 
@@ -384,7 +384,7 @@ Step 2: Setup ZFS
            -O encryption=aes-256-gcm \
            -O keylocation=prompt -O keyformat=passphrase \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool ${DISKP}2
 
@@ -395,7 +395,7 @@ Step 2: Setup ZFS
        zpool create \
            -o ashift=12 \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool /dev/mapper/luks1
 
@@ -420,6 +420,8 @@ Step 2: Setup ZFS
      of why requiring UTF-8 filenames may be a bad idea, see `The problems
      with enforced UTF-8 only filenames
      <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
+     A previous version of this guide suggested this setting, but it was 
+     reverted because of those problems.
    - ``recordsize`` is unset (leaving it at the default of 128 KiB). If you
      want to tune it (e.g. ``-o recordsize=1M``), see `these
      <https://jrs-s.net/2019/04/03/on-zfs-recordsize/>`__ `various

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
@@ -410,7 +410,7 @@ Step 2: Disk Formatting
          -o feature@lz4_compress=enabled \
          -o feature@spacemap_histogram=enabled \
          -O acltype=posixacl -O canmount=off -O compression=lz4 \
-         -O devices=off -O normalization=formD -O relatime=on -O xattr=sa \
+         -O devices=off -O relatime=on -O xattr=sa \
          -O mountpoint=/boot -R /mnt \
          bpool ${DISK}-part3
 
@@ -469,7 +469,7 @@ Step 2: Disk Formatting
        zpool create \
            -o ashift=12 -o autotrim=on \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool ${DISK}-part4
 
@@ -480,7 +480,7 @@ Step 2: Disk Formatting
            -O encryption=aes-256-gcm \
            -O keylocation=prompt -O keyformat=passphrase \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool ${DISK}-part4
 
@@ -491,7 +491,7 @@ Step 2: Disk Formatting
        zpool create \
            -o ashift=12 -o autotrim=on \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool /dev/mapper/luks1
 
@@ -509,13 +509,6 @@ Step 2: Disk Formatting
      <https://askubuntu.com/questions/970886/journalctl-says-failed-to-search-journal-acl-operation-not-supported>`__
      Also, `disabling ACLs apparently breaks umask handling with NFSv4
      <https://bugs.launchpad.net/ubuntu/+source/nfs-utils/+bug/1779736>`__.
-   - Setting ``normalization=formD`` eliminates some corner cases relating
-     to UTF-8 filename normalization. It also implies ``utf8only=on``,
-     which means that only UTF-8 filenames are allowed. If you care to
-     support non-UTF-8 filenames, do not use this option. For a discussion
-     of why requiring UTF-8 filenames may be a bad idea, see `The problems
-     with enforced UTF-8 only filenames
-     <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
    - ``recordsize`` is unset (leaving it at the default of 128 KiB). If you
      want to tune it (e.g. ``-o recordsize=1M``), see `these
      <https://jrs-s.net/2019/04/03/on-zfs-recordsize/>`__ `various
@@ -585,6 +578,15 @@ Step 2: Disk Formatting
    - The pool name is arbitrary. If changed, the new name must be used
      consistently. On systems that can automatically install to ZFS, the root
      pool is named ``rpool`` by default.
+   - Setting ``normalization=formD`` eliminates some corner cases relating
+     to UTF-8 filename normalization. It also implies ``utf8only=on``,
+     which means that only UTF-8 filenames are allowed. If you care to
+     support non-UTF-8 filenames, do not use this option. For a discussion
+     of why requiring UTF-8 filenames may be a bad idea, see `The problems
+     with enforced UTF-8 only filenames
+     <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
+     A previous version of this guide suggested this setting, but it was 
+     reverted because of those problems.
 
 Step 3: System Installation
 ---------------------------

--- a/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS for Raspberry Pi.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS for Raspberry Pi.rst
@@ -370,7 +370,7 @@ Step 2: Setup ZFS
        zpool create \
            -o ashift=12 \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool ${DISKP}2
 
@@ -383,7 +383,7 @@ Step 2: Setup ZFS
            -O encryption=aes-256-gcm \
            -O keylocation=prompt -O keyformat=passphrase \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool ${DISKP}2
 
@@ -394,7 +394,7 @@ Step 2: Setup ZFS
        zpool create \
            -o ashift=12 \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool /dev/mapper/luks1
 
@@ -412,6 +412,8 @@ Step 2: Setup ZFS
      <https://askubuntu.com/questions/970886/journalctl-says-failed-to-search-journal-acl-operation-not-supported>`__
      Also, `disabling ACLs apparently breaks umask handling with NFSv4
      <https://bugs.launchpad.net/ubuntu/+source/nfs-utils/+bug/1779736>`__.
+     A previous version of this guide suggested this setting, but it was 
+     reverted because of those problems.
    - Setting ``normalization=formD`` eliminates some corner cases relating
      to UTF-8 filename normalization. It also implies ``utf8only=on``,
      which means that only UTF-8 filenames are allowed. If you care to

--- a/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS.rst
@@ -290,7 +290,7 @@ Step 2: Disk Formatting
          -o feature@lz4_compress=enabled \
          -o feature@spacemap_histogram=enabled \
          -O acltype=posixacl -O canmount=off -O compression=lz4 \
-         -O devices=off -O normalization=formD -O relatime=on -O xattr=sa \
+         -O devices=off -O relatime=on -O xattr=sa \
          -O mountpoint=/boot -R /mnt \
          bpool ${DISK}-part3
 
@@ -349,7 +349,7 @@ Step 2: Disk Formatting
        zpool create \
            -o ashift=12 -o autotrim=on \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool ${DISK}-part4
 
@@ -360,7 +360,7 @@ Step 2: Disk Formatting
            -O encryption=aes-256-gcm \
            -O keylocation=prompt -O keyformat=passphrase \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool ${DISK}-part4
 
@@ -371,7 +371,7 @@ Step 2: Disk Formatting
        zpool create \
            -o ashift=12 -o autotrim=on \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool /dev/mapper/luks1
 
@@ -389,13 +389,6 @@ Step 2: Disk Formatting
      <https://askubuntu.com/questions/970886/journalctl-says-failed-to-search-journal-acl-operation-not-supported>`__
      Also, `disabling ACLs apparently breaks umask handling with NFSv4
      <https://bugs.launchpad.net/ubuntu/+source/nfs-utils/+bug/1779736>`__.
-   - Setting ``normalization=formD`` eliminates some corner cases relating
-     to UTF-8 filename normalization. It also implies ``utf8only=on``,
-     which means that only UTF-8 filenames are allowed. If you care to
-     support non-UTF-8 filenames, do not use this option. For a discussion
-     of why requiring UTF-8 filenames may be a bad idea, see `The problems
-     with enforced UTF-8 only filenames
-     <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
    - ``recordsize`` is unset (leaving it at the default of 128 KiB). If you
      want to tune it (e.g. ``-o recordsize=1M``), see `these
      <https://jrs-s.net/2019/04/03/on-zfs-recordsize/>`__ `various
@@ -465,6 +458,15 @@ Step 2: Disk Formatting
    - The pool name is arbitrary. If changed, the new name must be used
      consistently. On systems that can automatically install to ZFS, the root
      pool is named ``rpool`` by default.
+   - Setting ``normalization=formD`` eliminates some corner cases relating
+     to UTF-8 filename normalization. It also implies ``utf8only=on``,
+     which means that only UTF-8 filenames are allowed. If you care to
+     support non-UTF-8 filenames, do not use this option. For a discussion
+     of why requiring UTF-8 filenames may be a bad idea, see `The problems
+     with enforced UTF-8 only filenames
+     <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
+     A previous version of this guide suggested this setting, but it was 
+     reverted because of those problems.
 
 Step 3: System Installation
 ---------------------------

--- a/docs/Getting Started/openSUSE/openSUSE Leap Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Leap Root on ZFS.rst
@@ -236,7 +236,7 @@ Step 2: Disk Formatting
          -o feature@spacemap_histogram=enabled \
          -o feature@zpool_checkpoint=enabled \
          -O acltype=posixacl -O canmount=off -O compression=lz4 \
-         -O devices=off -O normalization=formD -O relatime=on -O xattr=sa \
+         -O devices=off -O relatime=on -O xattr=sa \
          -O mountpoint=/boot -R /mnt \
          bpool ${DISK}-part3
 
@@ -295,7 +295,7 @@ Step 2: Disk Formatting
            -o cachefile=/etc/zfs/zpool.cache \
            -o ashift=12 \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool ${DISK}-part4
 
@@ -307,7 +307,7 @@ Step 2: Disk Formatting
            -O encryption=aes-256-gcm \
            -O keylocation=prompt -O keyformat=passphrase \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool ${DISK}-part4
 
@@ -320,7 +320,7 @@ Step 2: Disk Formatting
            -o cachefile=/etc/zfs/zpool.cache \
            -o ashift=12 \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool /dev/mapper/luks1
 
@@ -336,13 +336,6 @@ Step 2: Disk Formatting
      ``-o acltype=posixacl`` (note: lowercase “o”) to the ``zfs create``
      for ``/var/log``, as `journald requires ACLs
      <https://askubuntu.com/questions/970886/journalctl-says-failed-to-search-journal-acl-operation-not-supported>`__
-   - Setting ``normalization=formD`` eliminates some corner cases relating
-     to UTF-8 filename normalization. It also implies ``utf8only=on``,
-     which means that only UTF-8 filenames are allowed. If you care to
-     support non-UTF-8 filenames, do not use this option. For a discussion
-     of why requiring UTF-8 filenames may be a bad idea, see `The problems
-     with enforced UTF-8 only filenames
-     <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
    - ``recordsize`` is unset (leaving it at the default of 128 KiB). If you
      want to tune it (e.g. ``-o recordsize=1M``), see `these
      <https://jrs-s.net/2019/04/03/on-zfs-recordsize/>`__ `various
@@ -406,6 +399,15 @@ Step 2: Disk Formatting
    - The pool name is arbitrary. If changed, the new name must be used
      consistently. On systems that can automatically install to ZFS, the root
      pool is named ``rpool`` by default.
+   - Setting ``normalization=formD`` eliminates some corner cases relating
+     to UTF-8 filename normalization. It also implies ``utf8only=on``,
+     which means that only UTF-8 filenames are allowed. If you care to
+     support non-UTF-8 filenames, do not use this option. For a discussion
+     of why requiring UTF-8 filenames may be a bad idea, see `The problems
+     with enforced UTF-8 only filenames
+     <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
+     A previous version of this guide suggested this setting, but it was 
+     reverted because of those problems.
 
 Step 3: System Installation
 ---------------------------

--- a/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
@@ -228,7 +228,7 @@ Step 2: Disk Formatting
          -o feature@spacemap_histogram=enabled \
          -o feature@zpool_checkpoint=enabled \
          -O acltype=posixacl -O canmount=off -O compression=lz4 \
-         -O devices=off -O normalization=formD -O relatime=on -O xattr=sa \
+         -O devices=off -O relatime=on -O xattr=sa \
          -O mountpoint=/boot -R /mnt \
          bpool ${DISK}-part3
 
@@ -287,7 +287,7 @@ Step 2: Disk Formatting
            -o cachefile=/etc/zfs/zpool.cache \
            -o ashift=12 \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool ${DISK}-part4
 
@@ -299,7 +299,7 @@ Step 2: Disk Formatting
            -O encryption=aes-256-gcm \
            -O keylocation=prompt -O keyformat=passphrase \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool ${DISK}-part4
 
@@ -312,7 +312,7 @@ Step 2: Disk Formatting
            -o cachefile=/etc/zfs/zpool.cache \
            -o ashift=12 \
            -O acltype=posixacl -O canmount=off -O compression=lz4 \
-           -O dnodesize=auto -O normalization=formD -O relatime=on \
+           -O dnodesize=auto -O relatime=on \
            -O xattr=sa -O mountpoint=/ -R /mnt \
            rpool /dev/mapper/luks1
 
@@ -328,13 +328,6 @@ Step 2: Disk Formatting
      ``-o acltype=posixacl`` (note: lowercase “o”) to the ``zfs create``
      for ``/var/log``, as `journald requires ACLs
      <https://askubuntu.com/questions/970886/journalctl-says-failed-to-search-journal-acl-operation-not-supported>`__
-   - Setting ``normalization=formD`` eliminates some corner cases relating
-     to UTF-8 filename normalization. It also implies ``utf8only=on``,
-     which means that only UTF-8 filenames are allowed. If you care to
-     support non-UTF-8 filenames, do not use this option. For a discussion
-     of why requiring UTF-8 filenames may be a bad idea, see `The problems
-     with enforced UTF-8 only filenames
-     <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
    - ``recordsize`` is unset (leaving it at the default of 128 KiB). If you
      want to tune it (e.g. ``-o recordsize=1M``), see `these
      <https://jrs-s.net/2019/04/03/on-zfs-recordsize/>`__ `various
@@ -398,6 +391,15 @@ Step 2: Disk Formatting
    - The pool name is arbitrary. If changed, the new name must be used
      consistently. On systems that can automatically install to ZFS, the root
      pool is named ``rpool`` by default.
+   - Setting ``normalization=formD`` eliminates some corner cases relating
+     to UTF-8 filename normalization. It also implies ``utf8only=on``,
+     which means that only UTF-8 filenames are allowed. If you care to
+     support non-UTF-8 filenames, do not use this option. For a discussion
+     of why requiring UTF-8 filenames may be a bad idea, see `The problems
+     with enforced UTF-8 only filenames
+     <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
+     A previous version of this guide suggested this setting, but it was 
+     reverted because of those problems.
 
 Step 3: System Installation
 ---------------------------


### PR DESCRIPTION
i have tried to convert a real, live workstation to ZFS and had to recreate all filesystems because of this silly settings. It actually failed to copy [source code from the supysonic project](https://github.com/spl0k/supysonic/tree/270fa9883b2f2bc98f1482a68f7d9022017af50b/tests/assets/%E6) (which was [eventually removed](https://github.com/spl0k/supysonic/pull/183), but still). I don't think we should suggest such an advanced setting by default and, in general, I find that this guide suggests too many exotic things, instead of focusing on "just install the thing with ZFS".