### PR TITLE
WIP: Reorder and regroup options

### DIFF
--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -226,9 +226,9 @@ Step 2: Disk Formatting
 #. Create the boot pool::
 
      zpool create \
-         -o cachefile=/etc/zfs/zpool.cache \
          -o ashift=12 \
          -o autotrim=on -d \
+         -o cachefile=/etc/zfs/zpool.cache \
          -o feature@async_destroy=enabled \
          -o feature@bookmarks=enabled \
          -o feature@embedded_data=enabled \
@@ -242,9 +242,9 @@ Step 2: Disk Formatting
          -o feature@lz4_compress=enabled \
          -o feature@spacemap_histogram=enabled \
          -o feature@zpool_checkpoint=enabled \
+         -O devices=off \
          -O acltype=posixacl -O xattr=sa \
          -O compression=lz4 \
-         -O devices=off \
          -O normalization=formD \
          -O relatime=on \
          -O canmount=off -O mountpoint=/boot -R /mnt \


### PR DESCRIPTION
So it seems most of my ideas of #307 were refused, which is fine. But there's one final idea that I think might reach consensus here, and it's that options should be regrouped together consistently and logically. For example, the `posixacl`, `xattr` and `dnodesize` options go together, `relatime` and `normalization` do not.

This PR attempts to clean that up in one example instructions, the Bullseye one that I am more familiar with. Ideally this would be done elsewhere, but I'm not going to waste any time on *that* until this is somewhat agreed on here. :)

Thanks!