### PR TITLE
Verify that zpool.cache is aware bpool and rpool [Debian Bullseye Tutorial]

### DIFF
--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -530,6 +530,15 @@ Step 3: System Installation
    An alternative to using ``debootstrap`` is to copy the entirety of a
    working system into the new ZFS root.
 
+#. Verify that zpool.cache is aware of both, bpool and rpool::
+
+      strings /etc/zfs/zpool.cache | grep -P '^rpool|bpool$' | uniq
+
+   In case the command does not output both pools::
+
+      zpool set cachefile=/etc/zfs/zpool.cache rpool
+      zpool set cachefile=/etc/zfs/zpool.cache bpool
+
 #. Copy in zpool.cache::
 
      mkdir /mnt/etc/zfs


### PR DESCRIPTION
Hey there,
I had some problems in the past with the Debian Bullseye ZFS on Root tutorial, where I suddenly ended up with a read-only filesystem during "Fix filesystem mount ordering". This extra step fixed the problem for me.

Some documentation told me to mention @rlaager ;-)
