### PR TITLE
Updates Root on ZFS guide 

### DIFF
--- a/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS.rst
@@ -12,9 +12,7 @@ Overview
 Ubuntu Installer
 ~~~~~~~~~~~~~~~~
 
-The Ubuntu installer still has ZFS support, but `it was almost removed for
-22.04 <https://bugs.launchpad.net/ubuntu/+source/ubiquity/+bug/1966773>`__
-and `it no longer installs zsys
+The Ubuntu installer still has ZFS support, but `it no longer installs zsys
 <https://bugs.launchpad.net/ubuntu/+source/ubiquity/+bug/1968150>`__.  At
 the moment, this HOWTO still uses zsys, but that will be probably be removed
 in the near future.


### PR DESCRIPTION
I've removed the part at the beginning of the guide which stated that ZFS was almost removed from the 22.04 installer. I'm pretty sure this wasn't the case and the belief of this came about because of the incorrectly named [launchpad issue](https://bugs.launchpad.net/ubuntu/+source/ubiquity/+bug/1966773). This mistakenly referenced ZFS instead of zsys. See the below update to the title of the issue:

![image](https://user-images.githubusercontent.com/1822529/173522293-f733b4d7-6204-4323-873b-555de3d93705.png)
