### PR TITLE
Use universal zfs-release RPM

### DIFF
--- a/docs/Getting Started/Fedora/index.rst
+++ b/docs/Getting Started/Fedora/index.rst
@@ -24,7 +24,7 @@ see below.
 
 #. Add ZFS repo::
 
-    dnf install -y https://zfsonlinux.org/fedora/zfs-release$(rpm -E %dist).noarch.rpm
+    dnf install -y https://zfsonlinux.org/fedora/zfs-release-fedora-2-1.noarch.rpm
 
    List of repos is available `here <https://github.com/zfsonlinux/zfsonlinux.github.com/tree/master/fedora>`__.
 

--- a/docs/Getting Started/RHEL-based distro/index.rst
+++ b/docs/Getting Started/RHEL-based distro/index.rst
@@ -26,10 +26,8 @@ encouraged to verify the authenticity of the ZFS on Linux public key using
 the fingerprint listed here.
 
 | **Location:** /etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux
-| **EL6 Package:** `zfs-release.el6.noarch.rpm`_ (zfs-0.8.x)
-| **EL7.9 Package:** `zfs-release.el7_9.noarch.rpm`_ (zfs-0.8.x)
-| **EL8.6 Package:** `zfs-release.el8_6.noarch.rpm`_ (>= zfs-2.0.5)
-| **Archived Repositories:** `el7_5`_, `el7_6`_, `el7_7`_, `el7_8`_, `el8_0`_, `el8_1`_, `el8_2`_, `el8_3`_, `el8_4`_, `el8_5`_
+| **EL6-8 Packages:** `zfs-release-el-2-1.noarch.rpm`
+| **Archived Repositories:** `el6`, `el7_5`_, `el7_6`_, `el7_7`_, `el7_8`_, `el8_0`_, `el8_1`_, `el8_2`_, `el8_3`_, `el8_4`_, `el8_5`_, `el8_6`_
 | **List of Repositories** `see repo page <https://github.com/zfsonlinux/zfsonlinux.github.com/tree/master/epel>`__
 
 | **Download from:**
@@ -38,12 +36,12 @@ the fingerprint listed here.
 
 For RHEL/CentOS versions 6 and 7 run::
 
- yum install https://zfsonlinux.org/epel/zfs-release$(rpm -E %dist).noarch.rpm
+ yum install https://zfsonlinux.org/epel/zfs-release-el-2-1.noarch.rpm
  rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux
 
-And for RHEL 8.6::
+And for RHEL 8::
 
- dnf install https://zfsonlinux.org/epel/zfs-release.el8_6.noarch.rpm
+ dnf install https://zfsonlinux.org/epel/zfs-release-el-2-1.noarch.rpm
  rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux
 
 After installing the *zfs-release* package and verifying the public key
@@ -160,18 +158,19 @@ RHEL 8-based distro Root on ZFS
 
 .. _kABI-tracking kmod: https://elrepoproject.blogspot.com/2016/02/kabi-tracking-kmod-packages.html
 .. _DKMS: https://en.wikipedia.org/wiki/Dynamic_Kernel_Module_Support
-.. _zfs-release.el6.noarch.rpm: https://zfsonlinux.org/epel/zfs-release.el6.noarch.rpm
-.. _zfs-release.el7_9.noarch.rpm: https://zfsonlinux.org/epel/zfs-release.el7_9.noarch.rpm
-.. _zfs-release.el8_6.noarch.rpm: https://zfsonlinux.org/epel/zfs-release.el8_6.noarch.rpm
+.. _zfs-release-el-2-1.noarch.rpm: https://zfsonlinux.org/epel/zfs-release-el-2-1.noarch.rpm
+.. _el6: https://zfsonlinux.org/epel/zfs-release.el6.noarch.rpm
 .. _el7_5: https://zfsonlinux.org/epel/zfs-release.el7_5.noarch.rpm
 .. _el7_6: https://zfsonlinux.org/epel/zfs-release.el7_6.noarch.rpm
 .. _el7_7: https://zfsonlinux.org/epel/zfs-release.el7_7.noarch.rpm
 .. _el7_8: https://zfsonlinux.org/epel/zfs-release.el7_8.noarch.rpm
+.. _el7_9: https://zfsonlinux.org/epel/zfs-release.el7_9.noarch.rpm
 .. _el8_0: https://zfsonlinux.org/epel/zfs-release.el8_0.noarch.rpm
 .. _el8_1: https://zfsonlinux.org/epel/zfs-release.el8_1.noarch.rpm
 .. _el8_2: https://zfsonlinux.org/epel/zfs-release.el8_2.noarch.rpm
 .. _el8_3: https://zfsonlinux.org/epel/zfs-release.el8_3.noarch.rpm
 .. _el8_4: https://zfsonlinux.org/epel/zfs-release.el8_4.noarch.rpm
-.. _el8_5: https://zfsonlinux.org/epel/zfs-release.el8_4.noarch.rpm
+.. _el8_5: https://zfsonlinux.org/epel/zfs-release.el8_5.noarch.rpm
+.. _el8_6: https://zfsonlinux.org/epel/zfs-release.el8_6.noarch.rpm
 
 .. _EPEL repository: https://fedoraproject.org/wiki/EPEL


### PR DESCRIPTION
We now have universal zfs-release RPMs that will work for all version of either Fedora or RHEL/CentOS:

https://github.com/zfsonlinux/zfsonlinux.github.com/pull/67

Update the docs to point to the new RPMs.