### PR TITLE
Update index.rst

### DIFF
--- a/docs/Getting Started/RHEL-based distro/index.rst
+++ b/docs/Getting Started/RHEL-based distro/index.rst
@@ -36,7 +36,7 @@ the fingerprint listed here.
 
 For RHEL/CentOS versions 6 and 7 run::
 
- yum install https://zfsonlinux.org/epel/zfs-release-el-2-1.noarch.rpm
+ yum install https://zfsonlinux.org/epel/zfs-release.el7_9.noarch.rpm
  rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux
 
 And for RHEL 8::


### PR DESCRIPTION
centos 7.9 with error like this:
rpmlib(PayloadIsZstd) <= 5.4.18-1 is needed by zfs-release-el-2-1.noarch