### PR TITLE
Apt: use kernel/headers meta packages

### DIFF
--- a/docs/Developer Resources/Building ZFS.rst
+++ b/docs/Developer Resources/Building ZFS.rst
@@ -54,7 +54,7 @@ The following dependencies should be installed to build the latest ZFS
 
 .. code:: sh
 
-   sudo apt install build-essential autoconf automake libtool gawk alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev libattr1-dev libelf-dev linux-headers-$(uname -r) python3 python3-dev python3-setuptools python3-cffi libffi-dev python3-packaging git libcurl4-openssl-dev
+   sudo apt install build-essential autoconf automake libtool gawk alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev libattr1-dev libelf-dev linux-headers-generic python3 python3-dev python3-setuptools python3-cffi libffi-dev python3-packaging git libcurl4-openssl-dev
 
 Build Options
 ~~~~~~~~~~~~~

--- a/docs/Developer Resources/Custom Packages.rst
+++ b/docs/Developer Resources/Custom Packages.rst
@@ -143,7 +143,7 @@ Make sure that the required packages are installed:
 
 .. code:: sh
 
-   sudo apt install build-essential autoconf automake libtool gawk alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev libattr1-dev libelf-dev linux-headers-$(uname -r) python3 python3-dev python3-setuptools python3-cffi libffi-dev python3-packaging
+   sudo apt install build-essential autoconf automake libtool gawk alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev libattr1-dev libelf-dev linux-headers-generic python3 python3-dev python3-setuptools python3-cffi libffi-dev python3-packaging
 
 `Get the source code <#get-the-source-code>`__.
 

--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -184,7 +184,7 @@ Step 2: Disk Formatting
      mdadm --zero-superblock --force $DISK
      # For an array using a partition:
      mdadm --zero-superblock --force ${DISK}-part2
-   
+
    If the disk was previously used with zfs::
 
      wipefs -a $DISK
@@ -623,7 +623,7 @@ Step 4: System Configuration
 
 #. Install ZFS in the chroot environment for the new system::
 
-     apt install --yes dpkg-dev linux-headers-amd64 linux-image-amd64
+     apt install --yes dpkg-dev linux-headers-generic linux-image-generic
 
      apt install --yes zfs-initramfs
 

--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -146,8 +146,7 @@ Step 1: Prepare The Install Environment
 
 #. Install ZFS in the Live CD environment::
 
-     apt install --yes debootstrap gdisk dkms dpkg-dev \
-         linux-headers-$(uname -r)
+     apt install --yes debootstrap gdisk dkms dpkg-dev linux-headers-amd64
 
      apt install --yes -t buster-backports --no-install-recommends zfs-dkms
 

--- a/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
@@ -130,7 +130,7 @@ connect with ``ssh user@IP``.
 
 ::
 
-  # apt install --yes debootstrap gdisk dkms dpkg-dev linux-headers-$(uname -r)
+  # apt install --yes debootstrap gdisk dkms dpkg-dev linux-headers-amd64
   # apt install --yes -t stretch-backports zfs-dkms
   # modprobe zfs
 

--- a/docs/Getting Started/Debian/index.rst
+++ b/docs/Getting Started/Debian/index.rst
@@ -39,7 +39,7 @@ Add the backports repository::
 Install the packages::
 
   apt update
-  apt install dpkg-dev linux-headers-$(uname -r) linux-image-amd64
+  apt install dpkg-dev linux-headers-generic linux-image-generic
   apt install zfs-dkms zfsutils-linux
 
 **Caution**: If you are in a poorly configured environment (e.g. certain VM or container consoles), when apt attempts to pop up a message on first install, it may fail to notice a real console is unavailable, and instead appear to hang indefinitely. To circumvent this, you can prefix the `apt install` commands with ``DEBIAN_FRONTEND=noninteractive``, like this::


### PR DESCRIPTION
- `generic` packages exist since bullseye
- older versions have `amd64` meta package

Closes #327