### PR TITLE
Removed dropped ncompress dependency for RHEL9

### DIFF
--- a/docs/Developer Resources/Custom Packages.rst
+++ b/docs/Developer Resources/Custom Packages.rst
@@ -82,7 +82,7 @@ ZFS 2.1 release:
 .. code:: sh
 
    sudo dnf config-manager --set-enabled crb
-   sudo dnf install --skip-broken epel-release gcc make autoconf automake libtool rpm-build kernel-rpm-macros libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel kernel-devel-$(uname -r) python3 python3-devel python3-setuptools python3-cffi libffi-devel ncompress
+   sudo dnf install --skip-broken epel-release gcc make autoconf automake libtool rpm-build kernel-rpm-macros libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel kernel-devel-$(uname -r) python3 python3-devel python3-setuptools python3-cffi libffi-devel
    sudo dnf install --skip-broken --enablerepo=epel python3-packaging dkms
 
 


### PR DESCRIPTION
As mentioned here [#13480](https://github.com/openzfs/zfs/issues/13480)
And fixed here [3c356622994f1837f42a0d4bcd6558a3b3749521](https://github.com/openzfs/zfs/commit/3c356622994f1837f42a0d4bcd6558a3b3749521)