### PR TITLE
Root on ZFS: Fix broken links

### DIFF
--- a/docs/Getting Started/Alpine Linux/Alpine Linux Root on ZFS.rst
+++ b/docs/Getting Started/Alpine Linux/Alpine Linux Root on ZFS.rst
@@ -1,6 +1,6 @@
 Alpine Linux Root on ZFS
 ========================
-`Start here <Root%20on%20ZFS/1-preparation.html>`__.
+Start from "Preparation".
 
 Contents
 --------

--- a/docs/Getting Started/Alpine Linux/index.rst
+++ b/docs/Getting Started/Alpine Linux/index.rst
@@ -29,7 +29,7 @@ Root on ZFS
 ZFS can be used as root file system for Fedora.
 An installation guide is available.
 
-`Start here <Root%20on%20ZFS/1-preparation.html>`__.
+Start from "Preparation".
 
 .. toctree::
   :maxdepth: 1

--- a/docs/Getting Started/Arch Linux/Arch Linux Root on ZFS.rst
+++ b/docs/Getting Started/Arch Linux/Arch Linux Root on ZFS.rst
@@ -1,6 +1,6 @@
 Arch Linux Root on ZFS
 ======================
-`Start here <Root%20on%20ZFS/1-preparation.html>`__.
+Start from "Preparation".
 
 Contents
 --------

--- a/docs/Getting Started/Arch Linux/index.rst
+++ b/docs/Getting Started/Arch Linux/index.rst
@@ -52,7 +52,7 @@ Root on ZFS
 ZFS can be used as root file system for Arch Linux.
 An installation guide is available.
 
-`Start here <Root%20on%20ZFS/1-preparation.html>`__.
+Start from "Preparation".
 
 .. toctree::
   :maxdepth: 1

--- a/docs/Getting Started/Fedora/Fedora Root on ZFS.rst
+++ b/docs/Getting Started/Fedora/Fedora Root on ZFS.rst
@@ -1,6 +1,6 @@
 Fedora Root on ZFS
 ======================
-`Start here <Root%20on%20ZFS/1-preparation.html>`__.
+Start from "Preparation".
 
 Contents
 --------

--- a/docs/Getting Started/Fedora/index.rst
+++ b/docs/Getting Started/Fedora/index.rst
@@ -90,7 +90,7 @@ Root on ZFS
 ZFS can be used as root file system for Fedora.
 An installation guide is available.
 
-`Start here <Root%20on%20ZFS/1-preparation.html>`__.
+Start from "Preparation".
 
 .. toctree::
   :maxdepth: 1

--- a/docs/Getting Started/NixOS/Root on ZFS.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS.rst
@@ -1,6 +1,6 @@
 NixOS Root on ZFS
 =======================================
-`Start here <Root%20on%20ZFS/1-preparation.html>`__.
+Start from "Preparation".
 
 Contents
 --------

--- a/docs/Getting Started/NixOS/index.rst
+++ b/docs/Getting Started/NixOS/index.rst
@@ -55,7 +55,7 @@ Root on ZFS
 ZFS can be used as root file system for NixOS.
 An installation guide is available.
 
-`Start here <Root%20on%20ZFS/1-preparation.html>`__.
+Start from "Preparation".
 
 .. toctree::
   :maxdepth: 1

--- a/docs/Getting Started/RHEL-based distro/RHEL-based distro Root on ZFS.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL-based distro Root on ZFS.rst
@@ -1,6 +1,6 @@
 RHEL Root on ZFS
 =======================================
-`Start here <RHEL%20-based%20distro%20Root%20on%20ZFS/1-preparation.html>`__.
+Start from "Preparation".
 
 Contents
 --------

--- a/docs/Getting Started/RHEL-based distro/index.rst
+++ b/docs/Getting Started/RHEL-based distro/index.rst
@@ -148,7 +148,7 @@ And for RHEL/CentOS 8 and newer::
 
 RHEL-based distro Root on ZFS
 -------------------------------
-`Start here <RHEL%20-based%20distro%20Root%20on%20ZFS/1-preparation.html>`__.
+Start from "Preparation".
 
 .. toctree::
   :maxdepth: 1


### PR DESCRIPTION
I just noticed that some links have extra space character in them due to being version-independent guides.

This PR removes extra space characters.  Sorry for the oversight.

@gmelikov

Signed-off-by: Maurice Zhou <ja@apvc.uk>