### PR TITLE
Point to new zfs-release-2-2 RPMs, add key

### DIFF
--- a/docs/Getting Started/Fedora/Root on ZFS/1-preparation.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/1-preparation.rst
@@ -56,7 +56,7 @@ Preparation
 
 #. Add ZFS repo::
 
-    dnf install -y https://zfsonlinux.org/fedora/zfs-release-fedora-2-1.noarch.rpm
+    dnf install -y https://zfsonlinux.org/fedora/zfs-release-2-2$(rpm --eval "%{dist}").noarch.rpm
 
 #. Check available repos::
 

--- a/docs/Getting Started/Fedora/Root on ZFS/2-system-installation.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/2-system-installation.rst
@@ -139,6 +139,6 @@ System Installation
     kernel-devel
 
     dnf --installroot=/mnt   --releasever=$(source /etc/os-release ; echo $VERSION_ID) -y install \
-    https://zfsonlinux.org/fedora/zfs-release-fedora-2-1.noarch.rpm
+    https://zfsonlinux.org/fedora/zfs-release-2-2$(rpm --eval "%{dist}").noarch.rpm
 
     dnf --installroot=/mnt   --releasever=$(source /etc/os-release ; echo $VERSION_ID) -y install zfs zfs-dracut

--- a/docs/Getting Started/Fedora/index.rst
+++ b/docs/Getting Started/Fedora/index.rst
@@ -24,7 +24,7 @@ see below.
 
 #. Add ZFS repo::
 
-    dnf install -y https://zfsonlinux.org/fedora/zfs-release-fedora-2-1.noarch.rpm
+    dnf install -y https://zfsonlinux.org/fedora/zfs-release-2-2$(rpm --eval "%{dist}").noarch.rpm
 
    List of repos is available `here <https://github.com/zfsonlinux/zfsonlinux.github.com/tree/master/fedora>`__.
 

--- a/docs/Getting Started/RHEL-based distro/index.rst
+++ b/docs/Getting Started/RHEL-based distro/index.rst
@@ -15,7 +15,7 @@ updated as new versions are released. Only the current repository for each
 major release is updated with new packages. Packages are available for the
 following configurations:
 
-| **EL Releases:** 6, 7.9, 8.6
+| **EL Releases:** 6, 7.9, 8.6, 9.0
 | **Architectures:** x86_64
 
 To simplify installation a *zfs-release* package is provided which includes
@@ -30,18 +30,23 @@ the fingerprint listed here.
 | **Archived Repositories:** `el6`, `el7_5`_, `el7_6`_, `el7_7`_, `el7_8`_, `el8_0`_, `el8_1`_, `el8_2`_, `el8_3`_, `el8_4`_, `el8_5`_, `el8_6`_
 | **List of Repositories** `see repo page <https://github.com/zfsonlinux/zfsonlinux.github.com/tree/master/epel>`__
 
-| **Download from:**
+| **Signing key1 (Centos 8 and older, Fedora 36 and older)**
   `pgp.mit.edu <https://pgp.mit.edu/pks/lookup?search=0xF14AB620&op=index&fingerprint=on>`__
 | **Fingerprint:** C93A FFFD 9F3F 7B03 C310 CEB6 A9D5 A1C0 F14A B620
 
+| **Signing key2 (Centos 9+, Fedora 37+)**
+  `pgp.mit.edu <https://pgp.mit.edu/pks/lookup?search=0xA599FD5E9DB84141&op=index&fingerprint=on>`__
+| **Fingerprint:** 7DC7 299D CF7C 7FD9 CD87 701B A599 FD5E 9DB8 4141
+
+
 For RHEL/CentOS versions 6 and 7 run::
 
- yum install https://zfsonlinux.org/epel/zfs-release-el-2-1.noarch.rpm
+ yum install https://zfsonlinux.org/epel/zfs-release-2-2$(rpm --eval "%{dist}").noarch.rpm
  rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux
 
-And for RHEL 8::
+And for RHEL 8-9::
 
- dnf install https://zfsonlinux.org/epel/zfs-release-el-2-1.noarch.rpm
+ dnf install https://zfsonlinux.org/epel/zfs-release-2-2$(rpm --eval "%{dist}").noarch.rpm
  rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux
 
 After installing the *zfs-release* package and verifying the public key


### PR DESCRIPTION
Add our new key for EL9+ and Fedora 37+, and update instructions to include EL9.  Also update links for Fedora/EL to use the
new zfs-release-2-2 RPM.