### PR TITLE
Add cryptsetup-initramfs package to include cryptsetup into initrd.

### DIFF
--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -636,7 +636,7 @@ Step 4: System Configuration
 
 #. For LUKS installs only, setup ``/etc/crypttab``::
 
-     apt install --yes cryptsetup
+     apt install --yes cryptsetup cryptsetup-initramfs
 
      echo luks1 /dev/disk/by-uuid/$(blkid -s UUID -o value ${DISK}-part4) \
          none luks,discard,initramfs > /etc/crypttab


### PR DESCRIPTION
The initrd cannot otherwise decrypt the partition.