### PR TITLE
Update Ubuntu 2022.04 link to 2022.04.1

### DIFF
--- a/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS.rst
@@ -35,8 +35,8 @@ Caution
 System Requirements
 ~~~~~~~~~~~~~~~~~~~
 
-- `Ubuntu 22.04 (“jammy”) Desktop CD
-  <https://releases.ubuntu.com/22.04/ubuntu-22.04-desktop-amd64.iso>`__
+- `Ubuntu 22.04.1 (“jammy”) Desktop CD
+  <https://releases.ubuntu.com/22.04.1/ubuntu-22.04.1-desktop-amd64.iso>`__
   (*not* any server images)
 - Installing on a drive which presents 4 KiB logical sectors (a “4Kn” drive)
   only works with UEFI booting. This not unique to ZFS. `GRUB does not and

--- a/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS.rst
@@ -111,9 +111,10 @@ encrypted once per disk.
 Step 1: Prepare The Install Environment
 ---------------------------------------
 
-#. Boot the Ubuntu Live CD. Select Try Ubuntu. Connect your system to the
-   Internet as appropriate (e.g. join your WiFi network). Open a terminal
-   (press Ctrl-Alt-T).
+#. Boot the Ubuntu Live CD. From the GRUB boot menu, select *Try or Install Ubuntu*.
+   On the *Welcome* page, select your preferred language and *Try Ubuntu*.
+   Connect your system to the Internet as appropriate (e.g. join your WiFi network).
+   Open a terminal (press Ctrl-Alt-T).
 
 #. Setup and update the repositories::
 
@@ -181,7 +182,7 @@ Step 2: Disk Formatting
 #. If you are re-using a disk, clear it as necessary:
 
    Ensure swap partitions are not in use::
-   
+
      swapoff --all
 
    If the disk was previously used in an MD array::


### PR DESCRIPTION
- Update Ubuntu image link to 22.04.01 (The 22.04 link is dead).
- Clarify *Step 1: Prepare The Install Environment_ boot wording.
- Remove some trailing spaces.