### PR TITLE
Revise example to modify recordsize to apply to the root dataset during the rpool creation step

### DIFF
--- a/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS.rst
@@ -426,7 +426,7 @@ Step 2: Disk Formatting
      with enforced UTF-8 only filenames
      <http://utcc.utoronto.ca/~cks/space/blog/linux/ForcedUTF8Filenames>`__.
    - ``recordsize`` is unset (leaving it at the default of 128 KiB). If you
-     want to tune it (e.g. ``-o recordsize=1M``), see `these
+     want to tune it (e.g. ``-O recordsize=1M``), see `these
      <https://jrs-s.net/2019/04/03/on-zfs-recordsize/>`__ `various
      <http://blog.programster.org/zfs-record-size>`__ `blog
      <https://utcc.utoronto.ca/~cks/space/blog/solaris/ZFSFileRecordsizeGrowth>`__


### PR DESCRIPTION
Change the provided example to tune the ``recordsize`` to apply to the root dataset given it's in the notes under the step creating the rpool. See https://github.com/openzfs/openzfs-docs/issues/345#issuecomment-1242657449