### PR TITLE
Update 3-system-configuration.rst

### DIFF
--- a/docs/Getting Started/RHEL-based distro/RHEL-based distro Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL-based distro Root on ZFS/3-system-configuration.rst
@@ -55,7 +55,7 @@ System Configuration
     for i in $m; do mount --rbind $i /mnt/$i; done
 
     history -w /mnt/home/sys-install-pre-chroot.txt
-    chroot /mnt /usr/bin/env DISK=$DISK bash --login
+    chroot /mnt /usr/bin/env DISK="$DISK" bash --login
 
 #. For SELinux, relabel filesystem on reboot::
 


### PR DESCRIPTION
without the double quotes, the $DISK variable expands and results in 
```
[root@localhost ~]# chroot /mnt /usr/bin/env DISK=$DISK bash --login
/usr/bin/env: ‘/dev/disk/by-id/wwn-0x600508b1001c46680978c356213dc600’: Permission denied
```
for reference:
```
[root@localhost ~]# echo $DISK
/dev/disk/by-id/wwn-0x600508b1001cf803b8ac03ccf5011c35 /dev/disk/by-id/wwn-0x600508b1001c46680978c356213dc600 /dev/disk/by-id/wwn-0x600508b1001c4bf31794728d8b90958a /dev/disk/by-id/wwn-0x600508b1001c208797a0d40855e950d7 /dev/disk/by-id/wwn-0x600508b1001cdcc2e9403757f53763e0
```
with double quotes, the $DISK variable inside the chroot works correctly