### PR TITLE
Add double quotes to DISK=$DISK

### DIFF
--- a/docs/Getting Started/Alpine Linux/Root on ZFS/2-system-installation.rst
+++ b/docs/Getting Started/Alpine Linux/Root on ZFS/2-system-installation.rst
@@ -157,7 +157,7 @@ System Installation
     m='/dev /proc /sys'
     for i in $m; do mount --rbind $i /mnt/$i; done
 
-    chroot /mnt /usr/bin/env DISK=$DISK sh
+    chroot /mnt /usr/bin/env DISK="$DISK" sh
 
 #. Rebuild initrd::
 

--- a/docs/Getting Started/Arch Linux/Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS/3-system-configuration.rst
@@ -60,7 +60,7 @@ System Configuration
 #. Chroot::
 
     history -w /mnt/home/sys-install-pre-chroot.txt
-    arch-chroot /mnt /usr/bin/env DISK=$DISK bash
+    arch-chroot /mnt /usr/bin/env DISK="$DISK" bash
 
 #. Generate locales::
 

--- a/docs/Getting Started/Fedora/Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/3-system-configuration.rst
@@ -55,7 +55,7 @@ System Configuration
     for i in $m; do mount --rbind $i /mnt/$i; done
 
     history -w /mnt/home/sys-install-pre-chroot.txt
-    chroot /mnt /usr/bin/env DISK=$DISK bash --login
+    chroot /mnt /usr/bin/env DISK="$DISK" bash --login
 
 #. For SELinux, relabel filesystem on reboot::
 

--- a/docs/Getting Started/RHEL-based distro/RHEL-based distro Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL-based distro Root on ZFS/3-system-configuration.rst
@@ -55,7 +55,7 @@ System Configuration
     for i in $m; do mount --rbind $i /mnt/$i; done
 
     history -w /mnt/home/sys-install-pre-chroot.txt
-    chroot /mnt /usr/bin/env DISK=$DISK bash --login
+    chroot /mnt /usr/bin/env DISK="$DISK" bash --login
 
 #. For SELinux, relabel filesystem on reboot::
 


### PR DESCRIPTION
Without the double quotes, the $DISK variable expands and will not handle multi-disk correctly.

Co-authored-by: @baberlevi

Signed-off-by: Maurice Zhou <ja@apvc.uk>