### PR TITLE
Add details for use of cryptsetup keyfiles

### DIFF
--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -646,6 +646,24 @@ Step 4: System Configuration
 
    **Hint:** If you are creating a mirror or raidz topology, repeat the
    ``/etc/crypttab`` entries for ``luks2``, etc. adjusting for each disk.
+   
+   If you're using keyfiles to decrypt your root system at boot, then you'll have to
+   prepare a special ``crypttab`` for the initramfs.  This is necessary because
+   the boot scripts expect to find the crypttab at ``/conf/conf.d/cryptroot`` inside
+   the image, and the format of that file differs slightly to the native crypttab.  You
+   can generate the correct format with a command like this::
+   
+     awk '/^luks.*/ {print "target=" $1 ",source=" $2 ",keyscript=cat,key=/cryptroot/keyfiles/" $1 ".key"}' /etc/crypttab
+   
+   The output should be something like this::
+   
+     target=luks-zfs1,source=UUID=a1234567-b123-c456-d789-abcdef012345,keyscript=cat,key=/cryptroot/keyfiles/luks-zfs1.key
+     target=luks-zfs2,source=UUID=e7654321-f321-a654-b987-012345abcdef,keyscript=cat,key=/cryptroot/keyfiles/luks-zfs2.key
+
+   **Note:** Storing your keyfiles in your initramfs is insecure in that if the
+   initramfs image is stored on an unecrypted volume an attacker with phsyical
+   access could trivially unlock your disks.  Additionally if the initrmafs image
+   on disk is readable by other users then anyone could also extract your keys.
 
 #. Install GRUB
 

--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -646,24 +646,25 @@ Step 4: System Configuration
 
    **Hint:** If you are creating a mirror or raidz topology, repeat the
    ``/etc/crypttab`` entries for ``luks2``, etc. adjusting for each disk.
-   
-   If you're using keyfiles to decrypt your root system at boot, then you'll have to
+
+   If you're using `keyfiles <https://cryptsetup-team.pages.debian.net/cryptsetup/README.initramfs.html#storing-keyfiles-directly-in-the-initrd>`_ or a `keyscript <https://cryptsetup-team.pages.debian.net/cryptsetup/README.keyctl.html>`_ to decrypt your root system at boot, then you'll have to
    prepare a special ``crypttab`` for the initramfs.  This is necessary because
    the boot scripts expect to find the crypttab at ``/conf/conf.d/cryptroot`` inside
    the image, and the format of that file differs slightly to the native crypttab.  You
    can generate the correct format with a command like this::
-   
+
      awk '/^luks.*/ {print "target=" $1 ",source=" $2 ",keyscript=cat,key=/cryptroot/keyfiles/" $1 ".key"}' /etc/crypttab
-   
+
    The output should be something like this::
-   
+
      target=luks-zfs1,source=UUID=a1234567-b123-c456-d789-abcdef012345,keyscript=cat,key=/cryptroot/keyfiles/luks-zfs1.key
      target=luks-zfs2,source=UUID=e7654321-f321-a654-b987-012345abcdef,keyscript=cat,key=/cryptroot/keyfiles/luks-zfs2.key
 
-   **Note:** Storing your keyfiles in your initramfs is insecure in that if the
-   initramfs image is stored on an unecrypted volume an attacker with phsyical
-   access could trivially unlock your disks.  Additionally if the initrmafs image
-   on disk is readable by other users then anyone could also extract your keys.
+   **Note:** Storing your keyfiles in initramfs on an unencrypted ``/boot`` volume is
+   insecure because an attacker with phsyical access could trivially unlock your
+   disks.  Additionally if the initramfs image on disk is readable by other users
+   then anyone could also extract your keys.  See the `official Debian cryptsetup
+   documentation <https://cryptsetup-team.pages.debian.net/cryptsetup/>`_ for more information.
 
 #. Install GRUB
 


### PR DESCRIPTION
If the system is to be unlocked with keyfiles then an additional step is needed to work around the fact cryptsetup doesn't handle ZFS devices any more.