### PR TITLE
Update openSUSE Tumbleweed Root on ZFS.rst

### DIFF
--- a/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
@@ -464,7 +464,7 @@ Step 3: System Installation
 
    If this system will store local email in /var/mail::
 
-     zfs create                                 rpool/var/mail
+     zfs create                                 rpool/var/spool/mail
 
    If this system will use Snap packages::
 


### PR DESCRIPTION
When mail dataset is created in /var/mail, the filesystem package will fail to install (as it does not expect /var/mail to be a directory, see https://archive.virtualmin.com/node/23096), so create it in /var/spool/mail instead as is usual.