### PR TITLE
add encryption option: per-user encrypted homdir

### DIFF
--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -951,10 +951,28 @@ Step 6: First Boot
    Replace ``YOUR_USERNAME`` with your desired username::
 
      username=YOUR_USERNAME
+     
+     Choose one of the following:
+     
+     - Unencrypted homedir or whole-disk encryption
+     
+       ::
 
-     zfs create rpool/home/$username
-     adduser $username
-
+         zfs create rpool/home/$username
+         adduser $username
+       
+     - Encrypted homdir per user, automatic decryption on login
+     
+       ::
+       
+         zfs create rpool/home/$username -o encryption=on -o keyformat=passphrase -o keylocation=prompt -o canmount=noauto
+         zfs mount rpool/home/$username
+         adduser $username
+         
+       **Note**: Use the same strong password for ZFS encryption and user password. Please note: After a breach of your password changing the ZFS password does not restore protection.
+     
+   In either case, continue::
+     
      cp -a /etc/skel/. /home/$username
      chown -R $username:$username /home/$username
      usermod -a -G audio,cdrom,dip,floppy,netdev,plugdev,sudo,video $username

--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -71,9 +71,9 @@ Contributing
 Encryption
 ~~~~~~~~~~
 
-This guide supports three different encryption options: unencrypted, ZFS
-native encryption, and LUKS. With any option, all ZFS features are fully
-available.
+This guide supports four different encryption options: unencrypted, ZFS
+native encryption, LUKS and per-user encrypted homedirs. With any option,
+all ZFS features are fully available.
 
 Unencrypted does not encrypt anything, of course. With no encryption
 happening, this option naturally has the best performance.
@@ -303,7 +303,7 @@ Step 2: Disk Formatting
 
    Choose one of the following options:
 
-   - Unencrypted::
+   - Unencrypted (choose this if you want per-user encyprtion later on)::
 
        zpool create \
            -o ashift=12 \

--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -93,6 +93,11 @@ entered at the console. Performance is good, but LUKS sits underneath ZFS, so
 if multiple disks (mirror or raidz topologies) are used, the data has to be
 encrypted once per disk.
 
+Per-user encrypted homdirs encrypts only the datasets for each user. The system
+boots without the need to enter a passphrase. No user-data is accessible until
+the user logs in. The homdirs-datasets are automatically unlocked on login and
+locked on last logout. Mixing encrypted and non-encrypted homdirs is supported.
+
 Step 1: Prepare The Install Environment
 ---------------------------------------
 


### PR DESCRIPTION
I am no developer, just a somewhat experienced user. I tried my very best to not do something stupid, but I don't know if I succeeded. It works here (TM). Feel free to change anything.

Please note: I'm on debian/testing, not on bullseye. *Should* make no difference...