### PR TITLE
Remove instruction to block disk cache

### DIFF
--- a/docs/Getting Started/NixOS/Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/3-system-configuration.rst
@@ -6,14 +6,6 @@ System Configuration
 .. contents:: Table of Contents
    :local:
 
-#. Disable cache, stale cache will prevent system from booting::
-
-     mkdir -p /mnt/etc/zfs/
-     rm -f /mnt/etc/zfs/zpool.cache
-     touch /mnt/etc/zfs/zpool.cache
-     chmod a-w /mnt/etc/zfs/zpool.cache
-     chattr +i /mnt/etc/zfs/zpool.cache
-
 #. Generate initial system configuration::
 
     nixos-generate-config --root /mnt


### PR DESCRIPTION
Originally when following [this repo's NixOS install instructions](https://openzfs.github.io/openzfs-docs/Getting%20Started/NixOS/Root%20on%20ZFS/3-system-configuration.html) to create an encrypted root setup with mirrored boot and efi partitions, it struck me as odd, that the instruction contained the step of forcefully blocking disk cache.

My NixOS server setup ran into very strange errors, discussed in-depth here: https://github.com/NixOS/nixpkgs/issues/214871. These only manifested after days of running. After lifting this disk cache block, multiple symptoms alleviated. 

@wizeman [mentioned](https://github.com/NixOS/nixpkgs/issues/214871#issuecomment-1419083608):
> What was really necessary to do after the installation to make the system boot is to do zpool export bpool and zpool export rpool. That would have been enough to make the system boot.

These instructions already contain the step:
> 9. Unmount filesystems:
> ```
> umount -Rl /mnt
> zpool export -a
> ```

By my logic, this export as step with `-a Exports all pools imported on the system` already satisfies the required step as explained by @wizeman.
As such the disk cache step should be removed, because it is not only unnecessary, but a prime suspect for making my setup highly unstable.

Of course, this should be signed-off from someone with a bit more insight into ZFS, before merging.