### PR TITLE
RHEL 9 needs kernel-abi-stablelists too

### DIFF
--- a/docs/Developer Resources/Custom Packages.rst
+++ b/docs/Developer Resources/Custom Packages.rst
@@ -82,7 +82,7 @@ ZFS 2.1 release:
 .. code:: sh
 
    sudo dnf config-manager --set-enabled crb
-   sudo dnf install --skip-broken epel-release gcc make autoconf automake libtool rpm-build kernel-rpm-macros libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel kernel-devel-$(uname -r) python3 python3-devel python3-setuptools python3-cffi libffi-devel
+   sudo dnf install --skip-broken epel-release gcc make autoconf automake libtool rpm-build kernel-rpm-macros libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel kernel-devel-$(uname -r) kernel-abi-stablelists-$(uname -r | sed 's/\.[^.]\+$//') python3 python3-devel python3-setuptools python3-cffi libffi-devel
    sudo dnf install --skip-broken --enablerepo=epel python3-packaging dkms
 
 


### PR DESCRIPTION
RHEL 9 kABI-tracking kmod build fails without kernel-abi-stablelists.