### PR TITLE
NixOS Root on ZFS: Do not bind mount /boot/efi

### DIFF
--- a/docs/Getting Started/NixOS/Root on ZFS/2-system-installation.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/2-system-installation.rst
@@ -128,6 +128,3 @@ System Installation
      mkdir -p /mnt/boot/efis/${i##*/}-part1
      mount -t vfat ${i}-part1 /mnt/boot/efis/${i##*/}-part1
     done
-
-    mkdir -p /mnt/boot/efi
-    mount -t vfat $(echo $DISK | cut -f1 -d\ )-part1 /mnt/boot/efi


### PR DESCRIPTION
Previously we used a bind mount from /boot/efis/*-part1 to /boot/efi to facilitate bootloader configuration. Recent reports indicate that this bind mount prevents the system from booting.  This pull request removes the bind mount.

Closes Pull Request #383.

@gmelikov 