### PR TITLE
NixOS: Add tip for wiping flash-based storage devices, escape hatch for rollback

### DIFF
--- a/docs/Getting Started/NixOS/Root on ZFS/2-system-installation.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/2-system-installation.rst
@@ -10,6 +10,11 @@ System Installation
 
      for i in ${DISK}; do
 
+     # wipe flash-based storage device to improve
+     # performance.
+     # ALL DATA WILL BE LOST
+     # blkdiscard -f $i
+
      sgdisk --zap-all $i
 
      sgdisk -n1:1M:+1G -t1:EF00 $i

--- a/docs/Getting Started/NixOS/Root on ZFS/configuration-immutable.nix
+++ b/docs/Getting Started/NixOS/Root on ZFS/configuration-immutable.nix
@@ -244,9 +244,11 @@ in {
   boot.loader.grub.devices =
     (map (diskName: zfsRoot.devNodes + diskName) zfsRoot.bootDevices);
   boot.initrd.postDeviceCommands = ''
-    zpool import -Nf rpool
-    zfs rollback -r rpool/nixos/empty@start
-    zpool export -a
+    if ! grep -q zfs_no_rollback /proc/cmdline; then
+      zpool import -N rpool
+      zfs rollback -r rpool/nixos/empty@start
+      zpool export -a
+    fi
   '';
 }
 


### PR DESCRIPTION
- Add a tip for erasing SSDs, due to [Chris Siebenmann's blog](https://utcc.utoronto.ca/~cks/space/blog/linux/ErasingSSDsWithBlkdiscard).
- Add an escape hatch if the user do **not** need to [erase root file system](https://grahamc.com/blog/erase-your-darlings) on reboot.

@gmelikov