### PR TITLE
Fix missing options to accompany comments

### DIFF
--- a/docs/Getting Started/NixOS/Root on ZFS/configuration-immutable.nix
+++ b/docs/Getting Started/NixOS/Root on ZFS/configuration-immutable.nix
@@ -44,9 +44,9 @@ in {
   #   useXkbConfig = true; # use xkbOptions in tty.
   # };
 
-  # Enable the X11 windowing system.
-
   # Configure keymap in X11
+  # services.xserver.layout = "us";
+  # services.xserver.xkbOptions = {
   #   "eurosign:e";
   #   "caps:escape" # map caps to escape.
   # };

--- a/docs/Getting Started/NixOS/Root on ZFS/configuration.nix
+++ b/docs/Getting Started/NixOS/Root on ZFS/configuration.nix
@@ -44,9 +44,9 @@ in {
   #   useXkbConfig = true; # use xkbOptions in tty.
   # };
 
-  # Enable the X11 windowing system.
-
   # Configure keymap in X11
+  # services.xserver.layout = "us";
+  # services.xserver.xkbOptions = {
   #   "eurosign:e";
   #   "caps:escape" # map caps to escape.
   # };


### PR DESCRIPTION
In my eyes the comments related to X11 should be removed or else be amended by option examples.
At least `xkbOptions` has to enclose the broken statement.