### PR TITLE
Add zfs_sha256_impl and zfs_sha512_impl to Checksums.rst

### DIFF
--- a/docs/Basic Concepts/Checksums.rst
+++ b/docs/Basic Concepts/Checksums.rst
@@ -129,7 +129,9 @@ parameters.
 Checksum  Results Filename                     ``zfs`` module parameter
 ========= ==================================== ========================
 Fletcher4 /proc/spl/kstat/zfs/fletcher_4_bench zfs_fletcher_4_impl
-all-other /proc/spl/kstat/zfs/chksum_bench     zfs_blake3_impl
+all-other /proc/spl/kstat/zfs/chksum_bench     zfs_blake3_impl,
+                                               zfs_sha256_impl,
+                                               zfs_sha512_impl
 ========= ==================================== ========================
 
 Disabling Checksums


### PR DESCRIPTION
We should add these two module parameter.

They can be used for setting up individual SIMD module parameters.