### PR TITLE
NixOS: enclose disk variable in double quotes

### DIFF
--- a/docs/Getting Started/NixOS/Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/3-system-configuration.rst
@@ -9,7 +9,7 @@ System Configuration
 #. Enter ephemeral nix-shell with git support::
 
      mkdir -p /mnt/etc/
-     echo DISK=$DISK > ~/disk
+     echo DISK=\"$DISK\" > ~/disk
 
      nix-shell -p git
 


### PR DESCRIPTION
Just discovered another bug.  This will cause multi-disk setups to be treated as the same as single disk, with all other disks except the first one ignored.  @gmelikov