### PR TITLE
NixOS: add support for ARM64 architecture with UEFI firmware

### DIFF
--- a/docs/Getting Started/NixOS/Root on ZFS/1-preparation.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/1-preparation.rst
@@ -6,6 +6,17 @@ Preparation
 .. contents:: Table of Contents
    :local:
 
+This guide supports x86_64 and arm64-efi architectures.
+
+**Note for Tow-Boot**
+
+`Tow-Boot firmware <https://tow-boot.org/>`__
+enables UEFI boot on many affordable arm64 based computers.  If
+using Tow-Boot, NixOS and Tow-Boot must be on separate disks.
+Example, Tow-Boot is installed to an SD card.  Then the SD card
+should not be also shared with NixOS.  Install NixOS to an external
+disk instead.
+
 #. Disable Secure Boot. ZFS modules can not be loaded if Secure Boot is enabled.
 #. Download `NixOS Live Image
    <https://nixos.org/download.html#download-nixos>`__ and boot from it.

--- a/docs/Getting Started/NixOS/Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/3-system-configuration.rst
@@ -39,6 +39,9 @@ System Configuration
      sed -i "s|\"hostId_placeholder\"|\"$(head -c4 /dev/urandom | od -A none -t x4| sed 's| ||g')\"|g" \
        /mnt/etc/nixos/hosts/exampleHost/default.nix
 
+     sed -i "s|\"systemType_placeholder\"|\"$(uname -m)-linux\"|g" \
+       /mnt/etc/nixos/flake.nix
+
 #. Set root password::
 
      rootPwd=$(mkpasswd -m SHA-512 -s)
@@ -48,10 +51,6 @@ System Configuration
      sed -i \
      "s|rootHash_placeholder|${rootPwd}|" \
      /mnt/etc/nixos/hosts/exampleHost/default.nix
-
-#. If using a system architecture other than amd64 (x86_64-linux), such as
-   ``aarch64-linux``, change architecture in
-   ``/mnt/etc/nixos/flake.nix``.
 
 #. Optional: add SSH public key for root and change host name in
    ``/mnt/etc/nixos/hosts/exampleHost/default.nix``.
@@ -66,10 +65,6 @@ System Configuration
 
      git -C /mnt/etc/nixos commit -asm 'initial installation'
 
-#. Exit ephemeral nix shell with git::
-
-     exit
-
 #. Update flake lock file to track latest system version::
 
      nix \
@@ -82,6 +77,10 @@ System Configuration
      nixos-install --no-root-passwd --flake "git+file:///mnt/etc/nixos#exampleHost"
 
    If the host name was changed, use the new host name in this command.
+
+#. Exit ephemeral nix shell with git::
+
+     exit
 
 #. Unmount filesystems::
 


### PR DESCRIPTION
This PR adds support for NixOS root on ZFS installation on ARM64 architecture with UEFI firmware.

I have been already testing ARM64 support with my OrangePi PC2 since a while ago.  Now it is finally ready.

@gmelikov 