### PR TITLE
Remove inappropriate spaces from mailing lists addresses

### DIFF
--- a/docs/Project and Community/Mailing Lists.rst
+++ b/docs/Project and Community/Mailing Lists.rst
@@ -9,19 +9,19 @@ Mailing Lists
 |                      |                      |                      |
 +======================+======================+======================+
 | `zfs-announce\       | A low-traffic list   | `archive             |
-| @list.zfsonlinux.    | for announcements    | <https://zfsonli     |
+| @list.zfsonlinux.\   | for announcements    | <https://zfsonli     |
 | org <https://zfsonli | such as new releases | nux.topicbox.com/gro |
 | nux.topicbox.com/gro |                      | ups/zfs-announce>`__ |
 | ups/zfs-announce>`__ |                      |                      |
 +----------------------+----------------------+----------------------+
 | `zfs-discuss\        | A user discussion    | `archive             |
-| @list.zfsonlinux     | list for issues      | <https://zfsonl      |
+| @list.zfsonlinux\    | list for issues      | <https://zfsonl      |
 | .org <https://zfsonl | related to           | inux.topicbox.com/gr |
 | inux.topicbox.com/gr | functionality and    | oups/zfs-discuss>`__ |
 | oups/zfs-discuss>`__ | usability            |                      |
 +----------------------+----------------------+----------------------+
-| `zfs\                | A development list   | `archive             |
-| -devel@list.zfsonlin | for developers to    | <https://zfso        |
+| `zfs-\               | A development list   | `archive             |
+| devel@list.zfsonlin\ | for developers to    | <https://zfso        |
 | ux.org <https://zfso | discuss technical    | nlinux.topicbox.com/ |
 | nlinux.topicbox.com/ | issues               | groups/zfs-devel>`__ |
 | groups/zfs-devel>`__ |                      |                      |


### PR DESCRIPTION
Just see the ugly spaces in <https://openzfs.github.io/openzfs-docs/Project%20and%20Community/Mailing%20Lists.html>.