### PR TITLE
Create all the non-existing parent datasets

### DIFF
--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -452,7 +452,7 @@ Step 3: System Installation
 
 #. Create filesystem datasets for the root and boot filesystems::
 
-     zfs create -o canmount=noauto -o mountpoint=/ rpool/ROOT/debian
+     zfs create -p -o canmount=noauto -o mountpoint=/ rpool/ROOT/debian
      zfs mount rpool/ROOT/debian
 
      zfs create -o mountpoint=/boot bpool/BOOT/debian

--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -445,7 +445,7 @@ Step 3: System Installation
 
 #. Create filesystem datasets for the root and boot filesystems::
 
-     zfs create -o canmount=noauto -o mountpoint=/ rpool/ROOT/debian
+     zfs create -p -o canmount=noauto -o mountpoint=/ rpool/ROOT/debian
      zfs mount rpool/ROOT/debian
 
      zfs create -o mountpoint=/boot bpool/BOOT/debian

--- a/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
@@ -346,7 +346,7 @@ manually created clones.
 
 ::
 
-  # zfs create -o canmount=noauto -o mountpoint=/ rpool/ROOT/debian
+  # zfs create -p -o canmount=noauto -o mountpoint=/ rpool/ROOT/debian
   # zfs mount rpool/ROOT/debian
 
   # zfs create -o canmount=noauto -o mountpoint=/boot bpool/BOOT/debian


### PR DESCRIPTION
during `during zfs create -p -o canmount=noauto -o mountpoint=/ rpool/ROOT/debian`

Without this, on a fresh system the following is observed:

zfs create -o canmount=noauto -o mountpoint=/ rpool/ROOT/debian cannot create 'rpool/ROOT/debian': parent does not exist

Ref docs: https://openzfs.github.io/openzfs-docs/Getting%20Started/Debian/Debian%20Bullseye%20Root%20on%20ZFS.html#step-3-system-installation

@rlaager