### PR TITLE
Clarify that NixOS cfg is needed to make zfs.ko available

### DIFF
--- a/docs/Getting Started/NixOS/index.rst
+++ b/docs/Getting Started/NixOS/index.rst
@@ -30,6 +30,10 @@ see below.
 
 Live image ships with ZFS support by default.
 
+Note that you need to apply these settings even if you don't need
+to boot from ZFS.  The kernel module 'zfs.ko' will not be available
+to modprobe until you make these changes and reboot.
+
 #. Import separate configration file for ZFS options::
 
     vim /etc/nixos/configuration.nix


### PR DESCRIPTION
The documented configuration changes for NixOS appear to be making zfs available for boot.  However, these changes are also required just to make the zfs.ko module available to modprobe even for users who don't need ZFS available at boot time.  Also, the kernel module does not appear until after a reboot, regardless of 'nixos-rebuild switch'.

(a more knowledgable NixOS user might know how to modprobe
 without a reboot, but I don't)