### PR TITLE
nixos: remove network manager, immutable root

### DIFF
--- a/docs/Getting Started/NixOS/Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/3-system-configuration.rst
@@ -91,22 +91,6 @@ System Configuration
 
      reboot
 
-#. NetworkManager is enabled by default.  To manage network
-   connections, execute::
-
-     nmtui
-
-#. Optional: immutable root filesystem can be enabled by setting
-   ``my.boot.immutable`` option to ``true``.
-   then execute::
-
-     nixos-rebuild boot
-
-   Then reboot.  You may need to make certain
-   adjustments to where configuration files are stored,
-   see `NixOS wiki <https://nixos.wiki/wiki/ZFS>`__ for
-   details.
-
 Replace a failed disk
 =====================
 


### PR DESCRIPTION
NixOS allows using multiple programs to manage your network settings, so not everyone necessarily has network manager installed. Immutable root is not an upstream setting and it shouldn't be recommended in the basic ZFS install guide.