### PR TITLE
NixOS: configure users in configuration.nix, not per-host config.

### DIFF
--- a/docs/Getting Started/NixOS/Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS/3-system-configuration.rst
@@ -50,7 +50,7 @@ System Configuration
 
      sed -i \
      "s|rootHash_placeholder|${rootPwd}|" \
-     /mnt/etc/nixos/hosts/exampleHost/default.nix
+     /mnt/etc/nixos/configuration.nix
 
 #. You can enable NetworkManager for wireless networks and GNOME
    desktop environment in ``configuration.nix``.


### PR DESCRIPTION
Revert to NixOS upstream configuration options.  Previously a unnecessary custom module was used.