### PR TITLE
fix dracut config in root on ZFS docs

### DIFF
--- a/docs/Getting Started/Fedora/Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS/3-system-configuration.rst
@@ -32,9 +32,9 @@ System Configuration
 #. Configure dracut::
 
     echo 'add_dracutmodules+=" zfs "' >> /mnt/etc/dracut.conf.d/zfs.conf
-    echo 'forced_drivers+=" zfs "' >> /mnt/etc/dracut.conf.d/zfs.conf
+    echo 'force_drivers+=" zfs "' >> /mnt/etc/dracut.conf.d/zfs.conf
     if grep mpt3sas /proc/modules; then
-      echo 'forced_drivers+=" mpt3sas "'  >> /mnt/etc/dracut.conf.d/zfs.conf
+      echo 'force_drivers+=" mpt3sas "'  >> /mnt/etc/dracut.conf.d/zfs.conf
     fi
     if grep virtio_blk /proc/modules; then
       echo 'filesystems+=" virtio_blk "' >> /mnt/etc/dracut.conf.d/fs.conf

--- a/docs/Getting Started/RHEL-based distro/RHEL-based distro Root on ZFS/3-system-configuration.rst
+++ b/docs/Getting Started/RHEL-based distro/RHEL-based distro Root on ZFS/3-system-configuration.rst
@@ -32,9 +32,9 @@ System Configuration
 #. Configure dracut::
 
     echo 'add_dracutmodules+=" zfs "' >> /mnt/etc/dracut.conf.d/zfs.conf
-    echo 'forced_drivers+=" zfs "' >> /mnt/etc/dracut.conf.d/zfs.conf
+    echo 'force_drivers+=" zfs "' >> /mnt/etc/dracut.conf.d/zfs.conf
     if grep mpt3sas /proc/modules; then
-      echo 'forced_drivers+=" mpt3sas "'  >> /mnt/etc/dracut.conf.d/zfs.conf
+      echo 'force_drivers+=" mpt3sas "'  >> /mnt/etc/dracut.conf.d/zfs.conf
     fi
     if grep virtio_blk /proc/modules; then
       echo 'filesystems+=" virtio_blk "' >> /mnt/etc/dracut.conf.d/fs.conf


### PR DESCRIPTION
step 3 incorrectly uses "forced_drivers";
the dracut config option is "force_drivers" (force, not force*d*)

see https://github.com/search?q=repo%3Adracutdevs%2Fdracut+force_drivers&type=code