### PR TITLE
Install ZFS in the Live CD environment in multiple steps to avoid errors

### DIFF
--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -138,7 +138,9 @@ Step 1: Prepare The Install Environment
 
 #. Install ZFS in the Live CD environment::
 
-     apt install --yes debootstrap gdisk zfsutils-linux
+     apt install dkms
+     apt install zfs-dkms --no-install-recommends
+     apt install debootstrap gdisk zfsutils-linux
 
 Step 2: Disk Formatting
 -----------------------


### PR DESCRIPTION
When installing zfsutils-linux on Debian it installs before zfs-dkms, but when installing it tries to modprobe zfs-dkms module, which is not yet available. So it would be nice to install zfs-dkms first, and only then zfsutils-linux.