### PR TITLE
Stop udev before zpool export

### DIFF
--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -940,6 +940,7 @@ Step 6: First Boot
 
      mount | grep -v zfs | tac | awk '/\/mnt/ {print $3}' | \
          xargs -i{} umount -lf {}
+     systemctl stop udev
      zpool export -a
 
 #. If this fails for rpool, mounting it on boot will fail and you will need to


### PR DESCRIPTION
In my setup systemd-udevd reproducible locks and prevent exporting the zpool with: `pool is busy`.

After stopping udev I was able to export the zpool. However shutting it down before rebooting the whole machine should not make it worse. Also much nicer than booting into an "dirty" zpool within initramfs.