### PR TITLE
Addresses comment in ne9z/openzfs-docs/pull/1

### DIFF
--- a/docs/Getting Started/Alpine Linux/Root on ZFS.rst
+++ b/docs/Getting Started/Alpine Linux/Root on ZFS.rst
@@ -34,8 +34,8 @@ Preparation
 #. Disable Secure Boot. ZFS modules can not be loaded if Secure Boot is enabled.
 #. Download latest extended variant of `Alpine Linux
    live image
-   <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.0-x86_64.iso>`__,
-   verify `checksum <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.0-x86_64.iso.asc>`__
+   <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.4-x86_64.iso>`__,
+   verify `checksum <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.4-x86_64.iso.asc>`__
    and boot from it.
 
    .. code-block:: sh
@@ -48,8 +48,8 @@ Preparation
 
       # check whether the download page exists
       # alpine version must be in sync with ci/cd test chroot tarball
-      curl --head --fail https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.0-x86_64.iso
-      curl --head --fail https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.0-x86_64.iso.asc
+      curl --head --fail https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.4-x86_64.iso
+      curl --head --fail https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.4-x86_64.iso.asc
 
 #. Login as root user.  There is no password.
 #. Configure Internet
@@ -199,9 +199,7 @@ System Installation
 
 #. Partition the disks.
 
-   Note: you must clear all existing partition tables and data structures from the disks,
-   especially those with existing ZFS pools or mdraid and those that have been used as live media.
-   Those data structures may interfere with boot process.
+   Note: you must clear all existing partition tables and data structures from target disks.
 
    For flash-based storage, this can be done by the blkdiscard command below:
    ::

--- a/docs/Getting Started/Arch Linux/Root on ZFS.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS.rst
@@ -42,8 +42,8 @@ Preparation
 
    Download latest extended variant of `Alpine Linux
    live image
-   <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.0-x86_64.iso>`__,
-   verify `checksum <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.0-x86_64.iso.asc>`__
+   <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.4-x86_64.iso>`__,
+   verify `checksum <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.4-x86_64.iso.asc>`__
    and boot from it.
 
    .. code-block:: sh
@@ -196,9 +196,7 @@ System Installation
 
 #. Partition the disks.
 
-   Note: you must clear all existing partition tables and data structures from the disks,
-   especially those with existing ZFS pools or mdraid and those that have been used as live media.
-   Those data structures may interfere with boot process.
+   Note: you must clear all existing partition tables and data structures from target disks.
 
    For flash-based storage, this can be done by the blkdiscard command below:
    ::
@@ -395,10 +393,10 @@ System Configuration
      apk add curl
 
      curl --fail-early --fail -L \
-     https://america.archive.pkgbuild.com/iso/2023.05.03/archlinux-bootstrap-x86_64.tar.gz \
+     https://america.archive.pkgbuild.com/iso/2023.09.01/archlinux-bootstrap-x86_64.tar.gz \
      -o rootfs.tar.gz
      curl --fail-early --fail -L \
-     https://america.archive.pkgbuild.com/iso/2023.05.03/archlinux-bootstrap-x86_64.tar.gz.sig \
+     https://america.archive.pkgbuild.com/iso/2023.09.01/archlinux-bootstrap-x86_64.tar.gz.sig \
      -o rootfs.tar.gz.sig
 
      apk add gnupg

--- a/docs/Getting Started/Fedora/Root on ZFS.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS.rst
@@ -43,8 +43,8 @@ Preparation
 
    Download latest extended variant of `Alpine Linux
    live image
-   <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.0-x86_64.iso>`__,
-   verify `checksum <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.0-x86_64.iso.asc>`__
+   <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.4-x86_64.iso>`__,
+   verify `checksum <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.4-x86_64.iso.asc>`__
    and boot from it.
 
    .. code-block:: sh
@@ -200,9 +200,7 @@ System Installation
 
 #. Partition the disks.
 
-   Note: you must clear all existing partition tables and data structures from the disks,
-   especially those with existing ZFS pools or mdraid and those that have been used as live media.
-   Those data structures may interfere with boot process.
+   Note: you must clear all existing partition tables and data structures from target disks.
 
    For flash-based storage, this can be done by the blkdiscard command below:
    ::
@@ -582,12 +580,13 @@ System Configuration
    ::
 
     rm -f /etc/localtime
+    rm -f /etc/hostname
     systemd-firstboot \
     --force \
     --locale=en_US.UTF-8 \
     --timezone=Etc/UTC \
     --hostname=testhost \
-    --keymap=us
+    --keymap=us || true
 
 #. Set root passwd
    ::
@@ -718,6 +717,16 @@ Bootloader
 
      # chroot ends here
      ZFS_ROOT_GUIDE_TEST
+
+#. On first reboot, SELinux policies will be applied, albeit
+   incompletely.  The computer will then reboot with incomplete
+   policies and fail to mount ``/run``, resulting in a failure.
+
+   Workaround is to append ``enforcing=0`` to kernel command line in
+   the GRUB menu, as many times as necessary, until the system
+   complete one successful boot.  The author of this guide has not
+   found out a way to solve this issue during installation.  Help is
+   appreciated.
 
 Post installaion
 ---------------------------

--- a/docs/Getting Started/NixOS/Root on ZFS.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS.rst
@@ -147,9 +147,7 @@ System Installation
 
 #. Partition the disks.
 
-   Note: you must clear all existing partition tables and data structures from the disks,
-   especially those with existing ZFS pools or mdraid and those that have been used as live media.
-   Those data structures may interfere with boot process.
+   Note: you must clear all existing partition tables and data structures from target disks.
 
    For flash-based storage, this can be done by the blkdiscard command below:
    ::
@@ -302,7 +300,7 @@ System Installation
       zfs create -o mountpoint=legacy rpool/nixos/home
       mkdir "${MNT}"/home
       mount -t zfs rpool/nixos/home "${MNT}"/home
-      zfs create -o mountpoint=legacy  rpool/nixos/var
+      zfs create -o mountpoint=none   rpool/nixos/var
       zfs create -o mountpoint=legacy rpool/nixos/var/lib
       zfs create -o mountpoint=legacy rpool/nixos/var/log
       zfs create -o mountpoint=none bpool/nixos
@@ -384,6 +382,10 @@ System Configuration
      sed -i "s|\"x86_64-linux\"|\"$(uname -m || true)-linux\"|g" \
        "${MNT}"/etc/nixos/flake.nix
 
+#. Detect kernel modules needed for boot
+
+   .. code-block:: sh
+
      cp "$(command -v nixos-generate-config || true)" ./nixos-generate-config
 
      chmod a+rw ./nixos-generate-config
@@ -398,10 +400,13 @@ System Configuration
 
    .. ifconfig:: zfs_root_test
 
-        ::
+     ::
 
-           # show generated config
-           cat  "${MNT}"/etc/nixos/hosts/exampleHost/default.nix
+       sed -i "s|\"kernelModules_placeholder\"|\"nvme\"|g" \
+         "${MNT}"/etc/nixos/hosts/exampleHost/default.nix
+
+       # show generated config
+       cat  "${MNT}"/etc/nixos/hosts/exampleHost/default.nix
 
 #. Set root password
 

--- a/docs/Getting Started/RHEL-based distro/Root on ZFS.rst
+++ b/docs/Getting Started/RHEL-based distro/Root on ZFS.rst
@@ -40,8 +40,8 @@ Preparation
 
    Download latest extended variant of `Alpine Linux
    live image
-   <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.0-x86_64.iso>`__,
-   verify `checksum <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.0-x86_64.iso.asc>`__
+   <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.4-x86_64.iso>`__,
+   verify `checksum <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.4-x86_64.iso.asc>`__
    and boot from it.
 
    .. code-block:: sh
@@ -195,9 +195,7 @@ System Installation
 
 #. Partition the disks.
 
-   Note: you must clear all existing partition tables and data structures from the disks,
-   especially those with existing ZFS pools or mdraid and those that have been used as live media.
-   Those data structures may interfere with boot process.
+   Note: you must clear all existing partition tables and data structures from target disks.
 
    For flash-based storage, this can be done by the blkdiscard command below:
    ::

--- a/scripts/zfs_root_guide_test.sh
+++ b/scripts/zfs_root_guide_test.sh
@@ -22,8 +22,8 @@ losetup --detach-all
 # it is easier to install rhel with Alpine Linux live media
 # which has native zfs support
 if ! test -f rootfs.tar.gz; then
-    curl --fail-early --fail -Lo rootfs.tar.gz https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-minirootfs-3.18.0-x86_64.tar.gz
-    curl --fail-early --fail -Lo rootfs.tar.gz.sig https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-minirootfs-3.18.0-x86_64.tar.gz.asc
+    curl --fail-early --fail -Lo rootfs.tar.gz https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-minirootfs-3.18.4-x86_64.tar.gz
+    curl --fail-early --fail -Lo rootfs.tar.gz.sig https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-minirootfs-3.18.4-x86_64.tar.gz.asc
     gpg --auto-key-retrieve --keyserver hkps://keyserver.ubuntu.com --verify rootfs.tar.gz.sig
 fi
 mkdir rootfs-"${distro}"


### PR DESCRIPTION
Routine distribution update to latest September 2023 version, or else Arch Linux will not work.

Fix NixOS CI/CD test.

Also, replace cumbersome sentence with a more straightforward one.