### PR TITLE
Add missing dependencies to Debian custom packages instructions

### DIFF
--- a/docs/Developer Resources/Custom Packages.rst
+++ b/docs/Developer Resources/Custom Packages.rst
@@ -168,7 +168,7 @@ To build RPM converted Debian packages:
    $ cd zfs
    $ ./configure --enable-systemd
    $ make -j1 deb-utils deb-kmod
-   $ for file in *.deb; do sudo gdebi -q --non-interactive $file; done
+   $ sudo apt-get install --fix-missing ./*.deb
 
 Starting from openzfs-2.2 release, native Debian packages can be built
 as follows:
@@ -179,7 +179,7 @@ as follows:
    $ ./configure
    $ make native-deb-utils native-deb-kmod
    $ rm ../openzfs-zfs-dkms_*.deb
-   $ for file in ../*.deb; do sudo gdebi -q --non-interactive $file; done
+   $ sudo apt-get install --fix-missing ../*.deb
 
 Native Debian packages build with pre-configured paths for Debian and
 Ubuntu. It's best not to override the paths during configure.
@@ -196,22 +196,21 @@ follows:
 
 .. code:: sh
 
-   $ sudo apt-get install dkms
    $ cd zfs
    $ ./configure --enable-systemd
    $ make -j1 deb-utils deb-dkms
-   $ for file in *.deb; do sudo gdebi -q --non-interactive $file; done
+   $ sudo apt-get install --fix-missing ./*.deb
 
 Starting from openzfs-2.2 release, native deb-based DKMS and user
 packages can be built as follows:
 
 .. code:: sh
 
-   $ sudo apt-get install dkms
+   $ sudo apt-get install dh-dkms
    $ cd zfs
    $ ./configure
    $ make native-deb-utils
-   $ for file in ../*.deb; do sudo gdebi -q --non-interactive $file; done
+   $ sudo apt-get install --fix-missing ../*.deb
 
 Get the Source Code
 -------------------


### PR DESCRIPTION
`gdebi-core` is needed and without `dh-dkms` installed I get this error:

```
ago@ares:~/src/zfs$ make native-deb-utils
cp contrib/debian/control debian/control; \
dpkg-buildpackage -b -rfakeroot -us -uc;
dpkg-buildpackage: info: source package openzfs-linux
dpkg-buildpackage: info: source version 2.1.99-1
dpkg-buildpackage: info: source distribution unstable
dpkg-buildpackage: info: source changed by Umer Saleem <usaleem@ixsystems.com>
dpkg-buildpackage: info: host architecture amd64
 dpkg-source --before-build .
 debian/rules clean
make[1]: Entering directory '/home/ago/src/zfs'
dh clean --with autoreconf,dkms,python3,sphinxdoc
dh: error: unable to load addon dkms: Can't locate Debian/Debhelper/Sequence/dkms.pm in @INC (you may need to install the Debian::Debhelper::Sequence::dkms module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.36.0 /usr/local/share/perl/5.36.0 /usr/lib/x86_64-linux-gnu/perl5/5.36 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.36 /usr/share/perl/5.36 /usr/local/lib/site_perl) at (eval 13) line 1.
BEGIN failed--compilation aborted at (eval 13) line 1.

make[1]: *** [debian/rules:28: clean] Error 255
make[1]: Leaving directory '/home/ago/src/zfs'
dpkg-buildpackage: error: debian/rules clean subprocess returned exit status 2
make: *** [Makefile:14320: native-deb-utils] Error 2
```