### PR TITLE
Add missing package in openSUSE Tumbleweed Root on ZFS

### DIFF
--- a/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
@@ -136,8 +136,8 @@ Step 1: Prepare The Install Environment
 
 #. Install ZFS in the Live CD environment::
 
-     zypper install zfs
-     zypper install gdisk dkms
+     zypper install zfs zfs-kmp-default
+     zypper install gdisk
      modprobe zfs
 
 Step 2: Disk Formatting


### PR DESCRIPTION
zfs does not contains the kernel module, zfs-kmp-default does. Add it to match Leap instructions.  DKMS is not needed.

```
$ uname -r
6.5.6-1-default
```

```
$ rpm -ql zfs-kmp-default
/usr/lib/modules/6.5.6-1-default
/usr/lib/modules/6.5.6-1-default/extra
/usr/lib/modules/6.5.6-1-default/extra/spl.ko
/usr/lib/modules/6.5.6-1-default/extra/zfs.ko
```

```
$ rpm -ql zfs | grep module
/usr/lib/dracut/modules.d
/usr/lib/dracut/modules.d/02zfsexpandknowledge
/usr/lib/dracut/modules.d/02zfsexpandknowledge/module-setup.sh
/usr/lib/dracut/modules.d/90zfs
/usr/lib/dracut/modules.d/90zfs/export-zfs.sh
/usr/lib/dracut/modules.d/90zfs/import-opts-generator.sh
/usr/lib/dracut/modules.d/90zfs/module-setup.sh
/usr/lib/dracut/modules.d/90zfs/mount-zfs.sh
/usr/lib/dracut/modules.d/90zfs/parse-zfs.sh
/usr/lib/dracut/modules.d/90zfs/zfs-env-bootfs.service
/usr/lib/dracut/modules.d/90zfs/zfs-generator.sh
/usr/lib/dracut/modules.d/90zfs/zfs-lib.sh
/usr/lib/dracut/modules.d/90zfs/zfs-load-key.sh
/usr/lib/dracut/modules.d/90zfs/zfs-needshutdown.sh
/usr/lib/dracut/modules.d/90zfs/zfs-nonroot-necessities.service
/usr/lib/dracut/modules.d/90zfs/zfs-rollback-bootfs.service
/usr/lib/dracut/modules.d/90zfs/zfs-snapshot-bootfs.service
/usr/lib/modules-load.d
/usr/lib/modules-load.d/zfs.conf
```