### PR TITLE
Use compatibility property while creating boot pool

### DIFF
--- a/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
@@ -233,21 +233,9 @@ Step 2: Disk Formatting
 
      zpool create \
          -o ashift=12 \
-         -o autotrim=on -d \
+         -o autotrim=on \
+         -o compatibility=grub2 \
          -o cachefile=/etc/zfs/zpool.cache \
-         -o feature@async_destroy=enabled \
-         -o feature@bookmarks=enabled \
-         -o feature@embedded_data=enabled \
-         -o feature@empty_bpobj=enabled \
-         -o feature@enabled_txg=enabled \
-         -o feature@extensible_dataset=enabled \
-         -o feature@filesystem_limits=enabled \
-         -o feature@hole_birth=enabled \
-         -o feature@large_blocks=enabled \
-         -o feature@livelist=enabled \
-         -o feature@lz4_compress=enabled \
-         -o feature@spacemap_histogram=enabled \
-         -o feature@zpool_checkpoint=enabled \
          -O devices=off \
          -O acltype=posixacl -O xattr=sa \
          -O compression=lz4 \


### PR DESCRIPTION
Since OpenZFS 2.1, the `compatibility` property has allowed users to specify groups of pool features, to maintain compatibility with specific systems or versions. The `grub2` feature set is designed for use with GRUB2 boot pools, so can be used here replacing a bunch of distinct feature settings.