### PR TITLE
Root on ZFS: Warn against native encryption; add NixOS tutorial for LUKS

### DIFF
--- a/docs/Getting Started/Alpine Linux/Root on ZFS.rst
+++ b/docs/Getting Started/Alpine Linux/Root on ZFS.rst
@@ -352,7 +352,7 @@ System Installation
 
    - Encrypted:
 
-     Pick a strong password. Once compromised, changing password will not keep your
+     Avoid ZFS send/recv when using native encryption, see `a ZFS developer's comment on this issue`__ and `this spreadsheet of bugs`__.    A LUKS-based guide has yet to be written. Once compromised, changing password will not keep your
      data safe. See ``zfs-change-key(8)`` for more info
 
      .. code-block:: sh
@@ -564,3 +564,6 @@ System Configuration
 
      # chroot ends here
      ZFS_ROOT_GUIDE_TEST
+
+.. _a ZFS developer's comment on this issue: https://ol.reddit.com/r/zfs/comments/10n8fsn/does_openzfs_have_a_new_developer_for_the_native/j6b8k1m/
+.. _this spreadsheet of bugs: https://docs.google.com/spreadsheets/d/1OfRSXibZ2nIE9DGK6swwBZXgXwdCPKgp4SbPZwTexCg/htmlview

--- a/docs/Getting Started/Arch Linux/Root on ZFS.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS.rst
@@ -350,7 +350,7 @@ System Installation
 
    - Encrypted:
 
-     Pick a strong password. Once compromised, changing password will not keep your
+     Avoid ZFS send/recv when using native encryption, see `a ZFS developer's comment on this issue`__ and `this spreadsheet of bugs`__.    A LUKS-based guide has yet to be written. Once compromised, changing password will not keep your
      data safe. See ``zfs-change-key(8)`` for more info
 
      .. code-block:: sh
@@ -675,3 +675,6 @@ Bootloader
 
      # chroot ends here
      ZFS_ROOT_GUIDE_TEST
+
+.. _a ZFS developer's comment on this issue: https://ol.reddit.com/r/zfs/comments/10n8fsn/does_openzfs_have_a_new_developer_for_the_native/j6b8k1m/
+.. _this spreadsheet of bugs: https://docs.google.com/spreadsheets/d/1OfRSXibZ2nIE9DGK6swwBZXgXwdCPKgp4SbPZwTexCg/htmlview

--- a/docs/Getting Started/Fedora/Root on ZFS.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS.rst
@@ -355,7 +355,7 @@ System Installation
 
    - Encrypted:
 
-     Pick a strong password. Once compromised, changing password will not keep your
+     Avoid ZFS send/recv when using native encryption, see `a ZFS developer's comment on this issue`__ and `this spreadsheet of bugs`__.    A LUKS-based guide has yet to be written. Once compromised, changing password will not keep your
      data safe. See ``zfs-change-key(8)`` for more info
 
      .. code-block:: sh
@@ -752,3 +752,6 @@ Post installaion
     dnf group install gnome-desktop
 
 #. Add new user, configure swap.
+
+.. _a ZFS developer's comment on this issue: https://ol.reddit.com/r/zfs/comments/10n8fsn/does_openzfs_have_a_new_developer_for_the_native/j6b8k1m/
+.. _this spreadsheet of bugs: https://docs.google.com/spreadsheets/d/1OfRSXibZ2nIE9DGK6swwBZXgXwdCPKgp4SbPZwTexCg/htmlview

--- a/docs/Getting Started/RHEL-based distro/Root on ZFS.rst
+++ b/docs/Getting Started/RHEL-based distro/Root on ZFS.rst
@@ -349,7 +349,7 @@ System Installation
 
    - Encrypted:
 
-     Pick a strong password. Once compromised, changing password will not keep your
+     Avoid ZFS send/recv when using native encryption, see `a ZFS developer's comment on this issue`__ and `this spreadsheet of bugs`__.    A LUKS-based guide has yet to be written. Once compromised, changing password will not keep your
      data safe. See ``zfs-change-key(8)`` for more info
 
      .. code-block:: sh
@@ -671,3 +671,6 @@ Post installaion
     dnf group install gnome-desktop
 
 #. Add new user, configure swap.
+
+.. _a ZFS developer's comment on this issue: https://ol.reddit.com/r/zfs/comments/10n8fsn/does_openzfs_have_a_new_developer_for_the_native/j6b8k1m/
+.. _this spreadsheet of bugs: https://docs.google.com/spreadsheets/d/1OfRSXibZ2nIE9DGK6swwBZXgXwdCPKgp4SbPZwTexCg/htmlview


### PR DESCRIPTION
Hopefully I've got the reStructuredText indentation right.  This PR contains two changes:

- Add warning against ZFS native encryption, with references
- Add LUKS-based guide for NixOS

Tested with https://github.com/ne9z/openzfs-docs/actions/runs/6651356857/job/18073228694