### PR TITLE
Root on ZFS: use compat=legacy with boot pool

### DIFF
--- a/docs/Getting Started/Alpine Linux/Root on ZFS.rst
+++ b/docs/Getting Started/Alpine Linux/Root on ZFS.rst
@@ -40,6 +40,10 @@ to their site for installation details.
 Unless stated otherwise, it is not recommended to customize system
 configuration before reboot.
 
+**Only use well-tested pool features**
+
+You should only use well-tested pool features.  Avoid using new features if data integrity is paramount.  See, for example, `this comment <https://github.com/openzfs/openzfs-docs/pull/464#issuecomment-1776918481>`__.
+
 Preparation
 ---------------------------
 

--- a/docs/Getting Started/Alpine Linux/Root on ZFS.rst
+++ b/docs/Getting Started/Alpine Linux/Root on ZFS.rst
@@ -275,23 +275,11 @@ System Installation
    ::
 
       # shellcheck disable=SC2046
-      zpool create -d \
-          -o feature@async_destroy=enabled \
-          -o feature@bookmarks=enabled \
-          -o feature@embedded_data=enabled \
-          -o feature@empty_bpobj=enabled \
-          -o feature@enabled_txg=enabled \
-          -o feature@extensible_dataset=enabled \
-          -o feature@filesystem_limits=enabled \
-          -o feature@hole_birth=enabled \
-          -o feature@large_blocks=enabled \
-          -o feature@lz4_compress=enabled \
-          -o feature@spacemap_histogram=enabled \
+      zpool create -o compatibility=legacy  \
           -o ashift=12 \
           -o autotrim=on \
           -O acltype=posixacl \
           -O canmount=off \
-          -O compression=lz4 \
           -O devices=off \
           -O normalization=formD \
           -O relatime=on \

--- a/docs/Getting Started/Arch Linux/Root on ZFS.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS.rst
@@ -273,23 +273,11 @@ System Installation
    ::
 
       # shellcheck disable=SC2046
-      zpool create -d \
-          -o feature@async_destroy=enabled \
-          -o feature@bookmarks=enabled \
-          -o feature@embedded_data=enabled \
-          -o feature@empty_bpobj=enabled \
-          -o feature@enabled_txg=enabled \
-          -o feature@extensible_dataset=enabled \
-          -o feature@filesystem_limits=enabled \
-          -o feature@hole_birth=enabled \
-          -o feature@large_blocks=enabled \
-          -o feature@lz4_compress=enabled \
-          -o feature@spacemap_histogram=enabled \
+      zpool create -o compatibility=legacy  \
           -o ashift=12 \
           -o autotrim=on \
           -O acltype=posixacl \
           -O canmount=off \
-          -O compression=lz4 \
           -O devices=off \
           -O normalization=formD \
           -O relatime=on \

--- a/docs/Getting Started/Arch Linux/Root on ZFS.rst
+++ b/docs/Getting Started/Arch Linux/Root on ZFS.rst
@@ -45,6 +45,10 @@ to their site for installation details.
 Unless stated otherwise, it is not recommended to customize system
 configuration before reboot.
 
+**Only use well-tested pool features**
+
+You should only use well-tested pool features.  Avoid using new features if data integrity is paramount.  See, for example, `this comment <https://github.com/openzfs/openzfs-docs/pull/464#issuecomment-1776918481>`__.
+
 Preparation
 ---------------------------
 

--- a/docs/Getting Started/Fedora/Root on ZFS.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS.rst
@@ -278,23 +278,11 @@ System Installation
    ::
 
       # shellcheck disable=SC2046
-      zpool create -d \
-          -o feature@async_destroy=enabled \
-          -o feature@bookmarks=enabled \
-          -o feature@embedded_data=enabled \
-          -o feature@empty_bpobj=enabled \
-          -o feature@enabled_txg=enabled \
-          -o feature@extensible_dataset=enabled \
-          -o feature@filesystem_limits=enabled \
-          -o feature@hole_birth=enabled \
-          -o feature@large_blocks=enabled \
-          -o feature@lz4_compress=enabled \
-          -o feature@spacemap_histogram=enabled \
+      zpool create -o compatibility=legacy  \
           -o ashift=12 \
           -o autotrim=on \
           -O acltype=posixacl \
           -O canmount=off \
-          -O compression=lz4 \
           -O devices=off \
           -O normalization=formD \
           -O relatime=on \

--- a/docs/Getting Started/Fedora/Root on ZFS.rst
+++ b/docs/Getting Started/Fedora/Root on ZFS.rst
@@ -46,6 +46,10 @@ to their site for installation details.
 Unless stated otherwise, it is not recommended to customize system
 configuration before reboot.
 
+**Only use well-tested pool features**
+
+You should only use well-tested pool features.  Avoid using new features if data integrity is paramount.  See, for example, `this comment <https://github.com/openzfs/openzfs-docs/pull/464#issuecomment-1776918481>`__.
+
 Preparation
 ---------------------------
 

--- a/docs/Getting Started/NixOS/Root on ZFS.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS.rst
@@ -206,13 +206,11 @@ System Installation
    ::
 
       # shellcheck disable=SC2046
-      zpool create \
-          -o compatibility=grub2 \
+      zpool create -o compatibility=legacy  \
           -o ashift=12 \
           -o autotrim=on \
           -O acltype=posixacl \
           -O canmount=off \
-          -O compression=lz4 \
           -O devices=off \
           -O normalization=formD \
           -O relatime=on \

--- a/docs/Getting Started/NixOS/Root on ZFS.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS.rst
@@ -29,6 +29,10 @@ Immutable root can be enabled or disabled by setting
 Unless stated otherwise, it is not recommended to customize system
 configuration before reboot.
 
+**Only use well-tested pool features**
+
+You should only use well-tested pool features.  Avoid using new features if data integrity is paramount.  See, for example, `this comment <https://github.com/openzfs/openzfs-docs/pull/464#issuecomment-1776918481>`__.
+
 Preparation
 ---------------------------
 

--- a/docs/Getting Started/RHEL-based distro/Root on ZFS.rst
+++ b/docs/Getting Started/RHEL-based distro/Root on ZFS.rst
@@ -43,6 +43,10 @@ to their site for installation details.
 Unless stated otherwise, it is not recommended to customize system
 configuration before reboot.
 
+**Only use well-tested pool features**
+
+You should only use well-tested pool features.  Avoid using new features if data integrity is paramount.  See, for example, `this comment <https://github.com/openzfs/openzfs-docs/pull/464#issuecomment-1776918481>`__.
+
 Preparation
 ---------------------------
 

--- a/docs/Getting Started/RHEL-based distro/Root on ZFS.rst
+++ b/docs/Getting Started/RHEL-based distro/Root on ZFS.rst
@@ -272,23 +272,11 @@ System Installation
    ::
 
       # shellcheck disable=SC2046
-      zpool create -d \
-          -o feature@async_destroy=enabled \
-          -o feature@bookmarks=enabled \
-          -o feature@embedded_data=enabled \
-          -o feature@empty_bpobj=enabled \
-          -o feature@enabled_txg=enabled \
-          -o feature@extensible_dataset=enabled \
-          -o feature@filesystem_limits=enabled \
-          -o feature@hole_birth=enabled \
-          -o feature@large_blocks=enabled \
-          -o feature@lz4_compress=enabled \
-          -o feature@spacemap_histogram=enabled \
+      zpool create -o compatibility=legacy  \
           -o ashift=12 \
           -o autotrim=on \
           -O acltype=posixacl \
           -O canmount=off \
-          -O compression=lz4 \
           -O devices=off \
           -O normalization=formD \
           -O relatime=on \


### PR DESCRIPTION
As mentioned [here](https://github.com/openzfs/openzfs-docs/issues/463#issuecomment-1775955088), compat=legacy seems to fix the problem where, once a snapshot of the root level dataset of the boot pool is taken, boot pool will become irreversibly unreadable by GRUB.

Also added a note against using less well-tested features in general.