### PR TITLE
compatibility_matrix: Fix osx for newer release

### DIFF
--- a/scripts/compatibility_matrix.py
+++ b/scripts/compatibility_matrix.py
@@ -48,7 +48,7 @@ def openzfs():
 
 def openzfsonosx():
     sources = {'main': 'https://raw.githubusercontent.com/openzfsonosx/'
-               'openzfs-fork/main/man/man7/zpool-features.7'}
+               'openzfs-fork/macOS/man/man7/zpool-features.7'}
     with urlopen('https://api.github.com/repos/openzfsonosx/openzfs-fork/tags') as web:
         try:
             tags = dejson(web.read().decode('utf-8', 'ignore'))

--- a/scripts/compatibility_matrix.py
+++ b/scripts/compatibility_matrix.py
@@ -47,14 +47,22 @@ def openzfs():
 
 
 def openzfsonosx():
-    sources = {'master': 'https://raw.githubusercontent.com/openzfsonosx/'
-               'openzfs/master/man/man5/zpool-features.5'}
-    with urlopen('https://api.github.com/repos/openzfsonosx/openzfs/tags') as web:
+    sources = {'main': 'https://raw.githubusercontent.com/openzfsonosx/'
+               'openzfs-fork/main/man/man7/zpool-features.7'}
+    with urlopen('https://api.github.com/repos/openzfsonosx/openzfs-fork/tags') as web:
         try:
             tags = dejson(web.read().decode('utf-8', 'ignore'))
-            tags = [x['name'].lstrip('zfs-macOS-') for x in tags]
+            tags = [x['name'].lstrip('zfs-macOS-') for x in tags if 'zfs-macOS-' in x['name']]
             tags = [tag for tag in tags if '.99' not in tag]
-            tags.sort()
+            def version_key(tag):
+                if 'rc' in tag:
+                    # fix inconsistent versioning
+                    tag = tag.replace('-','')
+                    version, rc = tag.split('rc')
+                    return (version, int(rc))
+                else:
+                    return (tag, 99)
+            tags.sort(key=version_key)
             latest = tags[-1]
             tags = [tag for tag in tags if 'rc' not in tag]
             if 'rc' not in latest:
@@ -64,8 +72,8 @@ def openzfsonosx():
         except Exception:
             tags = []
     for ver in tags:
-        sources[ver] = ('https://raw.githubusercontent.com/openzfsonosx/openzfs/'
-                        'zfs-macOS-{}/man/man5/zpool-features.5'.format(ver))
+        sources[ver] = ('https://raw.githubusercontent.com/openzfsonosx/openzfs-fork/'
+                        'zfs-macOS-{}/man/man7/zpool-features.7'.format(ver))
     return sources
 
 

--- a/scripts/compatibility_matrix.py
+++ b/scripts/compatibility_matrix.py
@@ -47,8 +47,21 @@ def openzfs():
 
 
 def openzfsonosx():
-    sources = {'main': 'https://raw.githubusercontent.com/openzfsonosx/'
-               'openzfs-fork/macOS/man/man7/zpool-features.7'}
+    with urlopen('https://api.github.com/repos/openzfsonosx/openzfs-fork/branches?per_page=100') as web:
+        try:
+            def is_date(date_str):
+                try:
+                    datetime.strptime(date_str, '%Y%m%d')
+                    return True
+                except ValueError:
+                    return False
+            branches = dejson(web.read().decode('utf-8', 'ignore'))
+            branches = [x['name'].lstrip('macOS_') for x in branches if 'macOS_' in x['name']]
+            branches = [x for x in branches if is_date(x)]
+            sources = {'main':('https://raw.githubusercontent.com/openzfsonosx/openzfs-fork/'
+                        'macOS_{}/man/man7/zpool-features.7'.format(max(branches)))}
+        except Exception:
+            sources = {}
     with urlopen('https://api.github.com/repos/openzfsonosx/openzfs-fork/tags') as web:
         try:
             tags = dejson(web.read().decode('utf-8', 'ignore'))


### PR DESCRIPTION
Development repo of openzfsonosx seems to have again changed from [openzfs](https://github.com/openzfsonosx/openzfs) to [openzfs-fork](https://github.com/openzfsonosx/openzfs-fork). New releases posted on the [forum](https://openzfsonosx.org/forum/viewforum.php?f=20) are tagged only on the fork repo.
Change the repo link and updated links for man page to zpool-features.7.
Also fixed the tag sorting to prioritize stable releases over rcs.
ps: apologies for the duplicate pr.