### PR TITLE
change mount /boot to mount /boot/efi

### DIFF
--- a/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
@@ -1110,7 +1110,7 @@ If needed, you can chroot into your installed environment::
   mount -t tmpfs tmpfs /mnt/run
   mkdir /mnt/run/lock
   chroot /mnt /bin/bash --login
-  mount /boot
+  mount /boot/efi
   mount -a
 
 Do whatever you need to do to fix your system.

--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -1159,7 +1159,7 @@ If needed, you can chroot into your installed environment::
   mount -t tmpfs tmpfs /mnt/run
   mkdir /mnt/run/lock
   chroot /mnt /bin/bash --login
-  mount /boot
+  mount /boot/efi
   mount -a
 
 Do whatever you need to do to fix your system.

--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -1096,7 +1096,7 @@ If needed, you can chroot into your installed environment::
   mount -t tmpfs tmpfs /mnt/run
   mkdir /mnt/run/lock
   chroot /mnt /bin/bash --login
-  mount /boot
+  mount /boot/efi
   mount -a
 
 Do whatever you need to do to fix your system.

--- a/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
@@ -1008,7 +1008,7 @@ If needed, you can chroot into your installed environment:
   # mount --rbind /proc /mnt/proc
   # mount --rbind /sys  /mnt/sys
   # chroot /mnt /bin/bash --login
-  # mount /boot
+  # mount /boot/efi
   # mount -a
 
 Do whatever you need to do to fix your system.

--- a/docs/Getting Started/Ubuntu/Ubuntu 18.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 18.04 Root on ZFS.rst
@@ -958,7 +958,7 @@ If needed, you can chroot into your installed environment::
   mount --rbind /proc /mnt/proc
   mount --rbind /sys  /mnt/sys
   chroot /mnt /bin/bash --login
-  mount /boot
+  mount /boot/efi
   mount -a
 
 Do whatever you need to do to fix your system.

--- a/docs/Getting Started/openSUSE/openSUSE Leap Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Leap Root on ZFS.rst
@@ -1198,7 +1198,7 @@ If needed, you can chroot into your installed environment::
   mount --make-private --rbind /proc /mnt/proc
   mount --make-private --rbind /sys  /mnt/sys
   chroot /mnt /bin/bash --login
-  mount /boot
+  mount /boot/efi
   mount -a
 
 Do whatever you need to do to fix your system.

--- a/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
@@ -1155,7 +1155,7 @@ If needed, you can chroot into your installed environment::
   mount --make-private --rbind /proc /mnt/proc
   mount --make-private --rbind /sys  /mnt/sys
   chroot /mnt /bin/bash --login
-  mount /boot
+  mount /boot/efi
   mount -a
 
 Do whatever you need to do to fix your system.


### PR DESCRIPTION
Per @rlaager suggestion I ran `grep -r "mount /boot$" docs` to identify all locations that had this string and have corrected all.

I have a high level of confidence that this is correct in all instances because all of the files had other instances of `mount /boot/efi` and the only place where `mount /boot` was found was in the rescue instructions.