### PR TITLE
Fix for Custom Packages page, packages for Debian\Ubuntu

### DIFF
--- a/docs/Developer Resources/Custom Packages.rst
+++ b/docs/Developer Resources/Custom Packages.rst
@@ -144,7 +144,7 @@ Make sure that the required packages are installed:
 
 .. code:: sh
 
-   sudo apt install build-essential autoconf automake libtool gawk alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev libattr1-dev libelf-dev linux-headers-generic python3 python3-dev python3-setuptools python3-cffi libffi-dev python3-packaging debhelper-compat dh-python po-debconf python3-all-dev python3-sphinx
+   sudo apt install build-essential autoconf automake libtool gawk alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev libattr1-dev libelf-dev linux-headers-generic python3 python3-dev python3-setuptools python3-cffi libffi-dev python3-packaging debhelper-compat dh-python po-debconf python3-all-dev python3-sphinx libpam0g-dev
 
 `Get the source code <#get-the-source-code>`__.
 


### PR DESCRIPTION
Fix for native-deb-utils, it requires libpam0g-dev, otherwise dpkg-checkbuilddeps fails with error unmet build dependencies

The build was tested with currently released 2.2.2

![photo_2024-01-28_01-22-55](https://github.com/openzfs/openzfs-docs/assets/20700515/690753a0-925b-4ff6-ac8f-cc07c7633786)
