### PR TITLE
Fixed same typo in the Debian Bullseye and Bookworm docs.

### DIFF
--- a/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
@@ -902,7 +902,7 @@ Step 6: First Boot
      zpool export -a
 
 #. If this fails for rpool, mounting it on boot will fail and you will need to
-   ``zpool import -f rpool``, then ``exit`` in the initamfs prompt.
+   ``zpool import -f rpool``, then ``exit`` in the initramfs prompt.
 
 #. Reboot::
 

--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -951,7 +951,7 @@ Step 6: First Boot
      zpool export -a
 
 #. If this fails for rpool, mounting it on boot will fail and you will need to
-   ``zpool import -f rpool``, then ``exit`` in the initamfs prompt.
+   ``zpool import -f rpool``, then ``exit`` in the initramfs prompt.
 
 #. Reboot::
 


### PR DESCRIPTION
In the root on ZFS docs for both Debian Bullseye, and Bookworm, there is a typo where what should be "initramfs" reads "initamfs".