### PR TITLE
Add "parallel" to Debian/Ubuntu build dependencies

### DIFF
--- a/docs/Developer Resources/Building ZFS.rst
+++ b/docs/Developer Resources/Building ZFS.rst
@@ -54,7 +54,7 @@ The following dependencies should be installed to build the latest ZFS
 
 .. code:: sh
 
-   sudo apt install build-essential autoconf automake libtool gawk alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev libattr1-dev libelf-dev linux-headers-generic python3 python3-dev python3-setuptools python3-cffi libffi-dev python3-packaging git libcurl4-openssl-dev debhelper-compat dh-python po-debconf python3-all-dev python3-sphinx
+   sudo apt install build-essential autoconf automake libtool gawk alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev libattr1-dev libelf-dev linux-headers-generic python3 python3-dev python3-setuptools python3-cffi libffi-dev python3-packaging git libcurl4-openssl-dev debhelper-compat dh-python po-debconf python3-all-dev python3-sphinx parallel
 
 -  **FreeBSD**:
 


### PR DESCRIPTION
there's another variant from "moreutils" that doesn't support `-X0` which is used for `make checkstyle`. 

I'll file an issue for improving the detection there as well.