### PR TITLE
Clarify description of zfs_special_class_metadata_reserve_pct

### DIFF
--- a/docs/Performance and Tuning/Module Parameters.rst
+++ b/docs/Performance and Tuning/Module Parameters.rst
@@ -8249,7 +8249,7 @@ zfs_special_class_metadata_reserve_pct
 
 ``zfs_special_class_metadata_reserve_pct`` sets a threshold for space in
 special vdevs to be reserved exclusively for metadata. This prevents
-small blocks or dedup table from completely consuming a special vdev.
+small data blocks from completely consuming a special vdev.
 
 ====================================== ================================
 zfs_special_class_metadata_reserve_pct Notes


### PR DESCRIPTION
Current language in [Module Parameters#zfs-special-class-metadata-reserve-pct](https://openzfs.github.io/openzfs-docs/Performance%20and%20Tuning/Module%20Parameters.html#zfs-special-class-metadata-reserve-pct) states

> `zfs_special_class_metadata_reserve_pct` sets a threshold for space in special vdevs to be reserved exclusively for metadata. This prevents small blocks or dedup table from completely consuming a special vdev.

However based on [spa_misc.c#L1974](https://github.com/openzfs/zfs/blob/2e6b3c4d9453360a351af6148386360a3a7209b3/module/zfs/spa_misc.c#L1974) the codepath treats DDT objects the same as regular metadata, so the language in the docs was changed to clarify (emphasis in blockquote only)

> `zfs_special_class_metadata_reserve_pct` sets a threshold for space in special vdevs to be reserved exclusively for metadata. This prevents **small data blocks** from completely consuming a special vdev.

If the intent is to have DDT obey the reserve percentage then I can make the necessary changes to `spa_misc.c` instead.