### PR TITLE
fix: avoid unintended bold text in `Building ZFS.rst`

### DIFF
--- a/docs/Developer Resources/Building ZFS.rst
+++ b/docs/Developer Resources/Building ZFS.rst
@@ -11,12 +11,12 @@ git repository for the project is the `zfs
 
 There are two main components in this repository:
 
-- **ZFS**: The ZFS repository contains a copy of the upstream OpenZFS
+-  **ZFS**: The ZFS repository contains a copy of the upstream OpenZFS
    code which has been adapted and extended for Linux and FreeBSD. The
    vast majority of the core OpenZFS code is self-contained and can be
    used without modification.
 
-- **SPL**: The SPL is a thin shim layer which is responsible for
+-  **SPL**: The SPL is a thin shim layer which is responsible for
    implementing the fundamental interfaces required by OpenZFS. It's
    this layer which allows OpenZFS to be used across multiple
    platforms. SPL used to be maintained in a separate repository, but
@@ -74,7 +74,7 @@ depends on your requirements.
    downside to using packages it is greatly increases the time required
    to build, install, and test a change.
 
-- **In-tree**: Development can be done entirely in the SPL/ZFS source
+-  **In-tree**: Development can be done entirely in the SPL/ZFS source
    tree. This speeds up development by allowing developers to rapidly
    iterate on a patch. When working in-tree developers can leverage
    incremental builds, load/unload kernel modules, execute utilities,


### PR DESCRIPTION
In RST, spacing and indentation are significant, and consistent usage is essential for the correct parsing of the document.

Because the first line in the adjusted bullet points were differently indented than the following lines, the "boldness" of the first characters was extended to the whole line.

I noticed this by chance on [Building ZFS](https://openzfs.github.io/openzfs-docs/Developer%20Resources/Building%20ZFS.html) and fixed it in this one document. I did not review other pages for similar mistakes.