### PR TITLE
Add "magic" command to install only the kernel modules

### DIFF
--- a/docs/Developer Resources/Building ZFS.rst
+++ b/docs/Developer Resources/Building ZFS.rst
@@ -164,7 +164,8 @@ duration of your testing, edit ``/etc/depmod.d/ubuntu.conf`` and add
 
 You may then install using
 ``sudo make install; sudo ldconfig; sudo depmod``. You'd uninstall with
-``sudo make uninstall; sudo ldconfig; sudo depmod``.
+``sudo make uninstall; sudo ldconfig; sudo depmod``. You can install just
+the kernel modules with ``sudo make -C modules/ install``.
 
 .. _running-zloopsh-and-zfs-testssh:
 


### PR DESCRIPTION
While this is faster in every use case, it's especially useful when "cross-"compiling the kernel on one (fast) system and copying only the two .ko files to another, slower one where all the ZFS tools are already installed. It avoids "polluting" the build system with cutting-edge ZFS tools which may not even be needed there.

It's also more secure because it does not require "sudo" on build system where the "pseudo" install is run.

It's supported because `modules/` is defined as a SUBDIRS: https://www.gnu.org/software/automake/manual/html_node/Subdirectories.html

For SUBDIRS, automake generates the following comment in Makefile.am:
```
 # This directory's subdirectories are mostly independent; you can cd
 # into them and run 'make' without going through this Makefile.
 # ...
 $(am__recursive_targets):
```