### PR TITLE
Hardware.rst: Mention Kingston DC1000B

### DIFF
--- a/docs/Performance and Tuning/Hardware.rst
+++ b/docs/Performance and Tuning/Hardware.rst
@@ -505,6 +505,7 @@ follows:
 
 -  Intel 750
 -  Intel DC P3500/P3600/P3608/P3700
+-  Kingston DC100B (M.2 2280 form factor, fits into most laptops)
 -  Micron 7300/7400/7450 PRO/MAX
 -  Samsung PM963 (M.2 form factor)
 -  Samsung PM1725/PM1725a


### PR DESCRIPTION
I've been using this one with ZFS in my laptop for years, with it being one of the only M.2 devices that are short enough for laptops while still having power loss protection.

Source: https://www.kingston.com/en/ssd/dc1000b-data-center-boot-ssd