### PR TITLE
Fix the Fedora installation guide formatting

### DIFF
--- a/docs/Getting Started/Fedora/index.rst
+++ b/docs/Getting Started/Fedora/index.rst
@@ -68,9 +68,11 @@ see below.
 
 #. By default ZFS may be removed by kernel package updates.
    To lock the kernel version to only ones supported by ZFS to prevent this::
+
     echo 'zfs' > /etc/dnf/protected.d/zfs.conf
 
    Pending non-kernel updates can still be applied::
+
     dnf update --exclude=kernel*
 
 Testing Repo


### PR DESCRIPTION
The first missing line was generating a build warning for me even though I think it's been rendering fine::

    ~/projects/openzfs-docs/docs% make html
    Running Sphinx v7.3.7
    building [mo]: targets for 0 po files that are out of date
    writing output...
    building [html]: targets for 564 source files that are out of date
    updating environment: [new config] 564 added, 0 changed, 0 removed
    reading sources... [100%] msg/index
    /Users/user/projects/openzfs-docs/docs/Getting Started/Fedora/index.rst:71: ERROR: Unexpected indentation.
    (...)

The second missing line was actually making the "dns update ..." part not render as intended.