### PR TITLE
Use raw string literals for these two regexps

### DIFF
--- a/scripts/man_pages.py
+++ b/scripts/man_pages.py
@@ -53,10 +53,10 @@ TAG_REGEX = re.compile(
     r'zfs-(?P<version>'
     r'(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<fix>[0-9]+))')
 
-LINKS_REGEX_TEMPLATE = ('<a(?P<href_place> )class=\"Xr\"(?P<title>.*?)>%s'
-                        '\((?P<num>[1-9])\)<\/a>')
-LINKS_FINAL_REGEX = ('<a href="../\g<num>/\g<name>.\g<num>.html" class="Xr"'
-                     '>\g<name>(\g<num>)</a>')
+LINKS_REGEX_TEMPLATE = (r'<a(?P<href_place> )class=\"Xr\"(?P<title>.*?)>%s'
+                        r'\((?P<num>[1-9])\)<\/a>')
+LINKS_FINAL_REGEX = (r'<a href="../\g<num>/\g<name>.\g<num>.html" class="Xr"'
+                     r'>\g<name>(\g<num>)</a>')
 
 
 def add_hyperlinks(out_dir, version, pages):


### PR DESCRIPTION
This eliminates Python warnings that used to be printed when running the script:

    ~/projects/openzfs-docs/docs% ../scripts/man_pages.py .
    /Users/user/projects/openzfs-docs/docs/../scripts/man_pages.py:57: SyntaxWarning: invalid escape sequence '\('
      '\((?P<num>[1-9])\)<\/a>')
    /Users/user/projects/openzfs-docs/docs/../scripts/man_pages.py:58: SyntaxWarning: invalid escape sequence '\g'
      LINKS_FINAL_REGEX = ('<a href="../\g<num>/\g<name>.\g<num>.html" class="Xr"'
    /Users/user/projects/openzfs-docs/docs/../scripts/man_pages.py:59: SyntaxWarning: invalid escape sequence '\g'
      '>\g<name>(\g<num>)</a>')
    (...)