### PR TITLE
Update Fedora docs

### DIFF
--- a/docs/Getting Started/Fedora/index.rst
+++ b/docs/Getting Started/Fedora/index.rst
@@ -30,7 +30,7 @@ see below.
 
 #. Install kernel headers::
 
-     dnf install -y kernel-devel
+     dnf install -y kernel-devel-$(uname -r | awk -F'-' '{print $1}')
 
    ``kernel-devel`` package must be installed before ``zfs`` package.
 


### PR DESCRIPTION
Update docs to only install the kernel-devel package that matches the running kernel.  This is specifically needed when running in a live environment where kernel upgrades are not persisted after a reboot.

This was tested with the F40 Workstation installer