### PR TITLE
Add missing packages for Debian derived systems

### DIFF
--- a/docs/Developer Resources/Building ZFS.rst
+++ b/docs/Developer Resources/Building ZFS.rst
@@ -143,7 +143,7 @@ the ZFS and SPL source in the traditional autotools fashion.
 | **tip:** Native Debian packages build with pre-configured paths for
   Debian and Ubuntu. It's best not to override the paths during
   configure.
-| **tip:** For native Debain packages, ``KVERS``, ``KSRC`` and ``KOBJ``
+| **tip:** For native Debian packages, ``KVERS``, ``KSRC`` and ``KOBJ``
   environment variables can be exported to specify the kernel installed
   in non-default location.
 

--- a/docs/Developer Resources/Building ZFS.rst
+++ b/docs/Developer Resources/Building ZFS.rst
@@ -54,7 +54,7 @@ The following dependencies should be installed to build the latest ZFS
 
 .. code:: sh
 
-   sudo apt install build-essential autoconf automake libtool gawk alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev libattr1-dev libelf-dev linux-headers-generic python3 python3-dev python3-setuptools python3-cffi libffi-dev python3-packaging git libcurl4-openssl-dev debhelper-compat dh-python po-debconf python3-all-dev python3-sphinx parallel
+   sudo apt install alien autoconf automake build-essential debhelper-compat dh-autoreconf dh-dkms dh-python dkms fakeroot gawk git libaio-dev libattr1-dev libblkid-dev libcurl4-openssl-dev libelf-dev libffi-dev libpam0g-dev libssl-dev libtirpc-dev libtool libudev-dev linux-headers-generic parallel po-debconf python3 python3-all-dev python3-cffi python3-dev python3-packaging python3-setuptools python3-sphinx uuid-dev zlib1g-dev
 
 -  **FreeBSD**:
 


### PR DESCRIPTION
While building for Ubuntu 24.04, I documented that five packages were missing that were required for different aspects of configuration and building of ZFS, associated utilities, packaging and libraries.

I found that the _libpam0g-dev_ and _dh-dkms_ packages were clearly required by Debian 12 and Ubuntu 24.04 and not present on my provisioned installs.  In general, I believe all 5 packages are required on both platforms, although the different platforms appear to pull in some packages from other dependencies.

Specifically, these packages appear to be required for both Debian 12 and Ubuntu 24.04:

- dh-autoreconf
- dh-dkms
- libblkid-dev
- libpam0g-dev
- libtirpc-dev

As validation, I performed the build in parallel on a newly provisioned Ubuntu 24.04 VM and a newly provisioned Debian 12 VM.

I was specifically interested in building _native-deb_ and _native-deb-utils_ so the package list reflects that requirement.

 I followed these steps for Debian and Ubuntu:

```shell
$ sh autogen.sh
$ ./configure
$ make -s -j$(nproc)
$ make deb-native
$ make deb-native-utils
```
Incidentally fixed a typo.

Issues:

#457 