### PR TITLE
Update custom packages docs for Fedora/RHEL

### DIFF
--- a/docs/Developer Resources/Custom Packages.rst
+++ b/docs/Developer Resources/Custom Packages.rst
@@ -70,7 +70,7 @@ ZFS 2.1 release:
    sudo yum install epel-release gcc make autoconf automake libtool rpm-build libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel kernel-devel-$(uname -r) python python2-devel python-setuptools python-cffi libffi-devel ncompress
    sudo yum install --enablerepo=epel dkms python-packaging
 
--  **RHEL/CentOS 8, Fedora**:
+-  **RHEL/CentOS 8**:
 
 .. code:: sh
 
@@ -84,6 +84,13 @@ ZFS 2.1 release:
    sudo dnf config-manager --set-enabled crb
    sudo dnf install --skip-broken epel-release gcc make autoconf automake libtool rpm-build kernel-rpm-macros libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel kernel-devel-$(uname -r) kernel-abi-stablelists-$(uname -r | sed 's/\.[^.]\+$//') python3 python3-devel python3-setuptools python3-cffi libffi-devel
    sudo dnf install --skip-broken --enablerepo=epel python3-packaging dkms
+
+-  **Fedora 41**:
+
+.. code:: sh
+
+  sudo dnf install gcc make autoconf automake libtool rpm-build kernel-rpm-macros libtirpc-devel libblkid-devel libuuid-devel systemd-devel openssl-devel zlib-ng-compat-devel libaio-devel libattr-devel libffi-devel libunwind-devel kernel-devel-$(uname -r) python3 python3-devel openssl ncompress
+  sudo dnf install python3-packaging dkms
 
 
 

--- a/docs/Developer Resources/Custom Packages.rst
+++ b/docs/Developer Resources/Custom Packages.rst
@@ -128,6 +128,14 @@ options.
    $ make -j1 rpm-utils rpm-kmod
    $ sudo dnf install *.$(uname -m).rpm *.noarch.rpm
 
+**NOTE:** Fedora 41 Workstation includes the rpm package zfs-fuse
+which will prevent the installation of your own packages. Remove
+that single package before dnf install:
+
+.. code:: sh
+
+   $ sudo rpm -e --nodeps zfs-fuse
+
 kABI-tracking kmod
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/Developer Resources/Custom Packages.rst
+++ b/docs/Developer Resources/Custom Packages.rst
@@ -69,6 +69,8 @@ ZFS 2.1 release:
 
    sudo yum install epel-release gcc make autoconf automake libtool rpm-build libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel kernel-devel-$(uname -r) python python2-devel python-setuptools python-cffi libffi-devel ncompress
    sudo yum install --enablerepo=epel dkms python-packaging
+ 
+**NOTE:** RHEL/CentOS 7 is end of life. Use yum instead of dnf for install instructions below.
 
 -  **RHEL/CentOS 8**:
 
@@ -106,7 +108,7 @@ Building rpm-based DKMS and user packages can be done as follows:
    $ cd zfs
    $ ./configure
    $ make -j1 rpm-utils rpm-dkms
-   $ sudo yum localinstall *.$(uname -p).rpm *.noarch.rpm
+   $ sudo dnf install *.$(uname -m).rpm *.noarch.rpm
 
 kmod
 ~~~~
@@ -124,7 +126,7 @@ options.
    $ cd zfs
    $ ./configure
    $ make -j1 rpm-utils rpm-kmod
-   $ sudo yum localinstall *.$(uname -p).rpm
+   $ sudo dnf install *.$(uname -m).rpm *.noarch.rpm
 
 kABI-tracking kmod
 ~~~~~~~~~~~~~~~~~~
@@ -142,7 +144,7 @@ option must be passed to configure.
    $ cd zfs
    $ ./configure --with-spec=redhat
    $ make -j1 rpm-utils rpm-kmod
-   $ sudo yum localinstall *.$(uname -p).rpm
+   $ sudo dnf install *.$(uname -m).rpm *.noarch.rpm
 
 Debian and Ubuntu
 -----------------


### PR DESCRIPTION
@AllKind asked me to update the docs for Fedora in https://github.com/openzfs/zfs/issues/16807#issuecomment-2500530385

I've installed Fedora 41 Workstation in a virtual machine and checked which rpm packages are required to successfully build zfs (2.2.6.tar.gz and git 2.3.99). I've also added a paragraph about UEFI/secure boot which is common with Fedora. Just ignore the commit if you don't want that published. 