### PR TITLE
fix indentation to rejoin list (fixes #536)

### DIFF
--- a/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
@@ -828,10 +828,10 @@ Step 5: GRUB Installation
 
         grub-install $DISK
 
-   Note that you are installing GRUB to the whole disk, not a partition.
+      Note that you are installing GRUB to the whole disk, not a partition.
 
-   If you are creating a mirror or raidz topology, repeat the ``grub-install``
-   command for each disk in the pool.
+      If you are creating a mirror or raidz topology, repeat the ``grub-install``
+      command for each disk in the pool.
 
    #. For UEFI booting, install GRUB to the ESP::
 


### PR DESCRIPTION
fix indentation to rejoin list (fixes #536): article "Debian Bookworm Root on ZFS", [Step 5: GRUB Installation](https://openzfs.github.io/openzfs-docs/Getting%20Started/Debian/Debian%20Bookworm%20Root%20on%20ZFS.html#id11), list item 6: re-joins sublist to enumerate list items.

@rlaager - please have a look