### PR TITLE
Rocky Linux Root on ZFS: downgrade Alpine Linux to 3.18

### DIFF
--- a/docs/Getting Started/RHEL-based distro/Root on ZFS.rst
+++ b/docs/Getting Started/RHEL-based distro/Root on ZFS.rst
@@ -56,8 +56,8 @@ Preparation
 
    Download latest extended variant of `Alpine Linux
    live image
-   <https://dl-cdn.alpinelinux.org/alpine/v3.19/releases/x86_64/alpine-extended-3.19.0-x86_64.iso>`__,
-   verify `checksum <https://dl-cdn.alpinelinux.org/alpine/v3.19/releases/x86_64/alpine-extended-3.19.0-x86_64.iso.asc>`__
+   <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.4-x86_64.iso>`__,
+   verify `checksum <https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-extended-3.18.4-x86_64.iso.asc>`__
    and boot from it.
 
    .. code-block:: sh


### PR DESCRIPTION
Using Alpline Linux 3.19, Rocky Linux would fail during startup due to Alpine Linux having a newer zfs kmod version than the zfs tools version in Rocky Linux