### PR TITLE
Debian+Ubuntu root-on-zfs: add a last-resort command to export pool

### DIFF
--- a/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
@@ -903,7 +903,12 @@ Step 6: First Boot
          xargs -i{} umount -lf {}
      zpool export -a
 
-#. If this fails for rpool, mounting it on boot will fail and you will need to
+#. If export failed due to `busy` error, try to kill everything that might be using it::
+
+     grep [p]ool /proc/*/mounts | cut -d/ -f3 | uniq | xargs kill
+     zpool export -a
+
+#. If even after that your pool is busy, mounting it on boot will fail and you will need to
    ``zpool import -f rpool``, then ``exit`` in the initramfs prompt.
 
 #. Reboot::

--- a/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS.rst
@@ -988,6 +988,14 @@ Step 5: GRUB Installation
          xargs -i{} umount -lf {}
      zpool export -a
 
+#. If export failed due to `busy` error, try to kill everything that might be using it::
+
+     grep [p]ool /proc/*/mounts | cut -d/ -f3 | uniq | xargs kill
+     zpool export -a
+
+#. If even after that your pool is busy, mounting it on boot will fail and you will need to
+   ``zpool import -f rpool``, then ``exit`` in the initramfs prompt.
+
 #. Reboot::
 
      reboot


### PR DESCRIPTION
There may be orphan processes after chroot, so try to kill them.

With that I could get 100% reproducible export when I build cloud images (they have to boot first time successfully, otherwise it's not a ready-to use root-on-zfs image):
- https://github.com/infraguys/gci_ubuntu_zfs
- specifically - https://github.com/infraguys/gci_ubuntu_zfs/blob/master/templates/ubuntu-24/scripts/prepare-zfs-root.sh#L103-L119