### PR TITLE
CI: allow to run publish manually + try to deploy every night automatically + fix feature matrix build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
   workflow_dispatch:
+  schedule:
+    # every night, we have external data (man pages, feature matrix, etc)
+    - cron: "5 3 * * *"
 
 jobs:
   deploy:

--- a/scripts/compatibility_matrix.py
+++ b/scripts/compatibility_matrix.py
@@ -142,9 +142,9 @@ def joyent():
 
 
 def netbsd():
-    url = ('http://cvsweb.netbsd.org/bsdweb.cgi/~checkout~/src/external/'
-           'cddl/osnet/dist/cmd/zpool/zpool-features.7'
-           '?content-type=text/plain&only_with_tag={}')
+    url = ('http://cvsweb.netbsd.org/bsdweb.cgi/src/external/'
+           'cddl/osnet/dist/cmd/zpool/zpool-features.7?rev=1.1;'
+           'content-type=text%2Fplain;only_with_tag={}')
     sources = {'main': url.format('MAIN')}
     with urlopen('https://netbsd.org/releases/') as web:
         tags = findall(r'href="formal-.+?/NetBSD-(.+?)\.html',


### PR DESCRIPTION
Useful to regenerate for ex. man pages, if needed + because we have external data (man pages, feature matrix,
etc).