### PR TITLE
getting started: tell users to use partprobe

### DIFF
--- a/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
@@ -200,7 +200,12 @@ Step 2: Disk Formatting
      sgdisk --zap-all $DISK
 
    If you get a message about the kernel still using the old partition table,
-   reboot and start over (except that you can skip this step).
+   you can request the kernel reload the partition information using::
+
+     partprobe $DISK
+
+   If the new partitions still don't show up, you can reboot and start over
+   (except that you can skip this step).
 
 #. Partition your disk(s):
 

--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -207,7 +207,12 @@ Step 2: Disk Formatting
      sgdisk --zap-all $DISK
 
    If you get a message about the kernel still using the old partition table,
-   reboot and start over (except that you can skip this step).
+   you can request the kernel reload the partition information using::
+
+     partprobe $DISK
+
+   If the new partitions still don't show up, you can reboot and start over
+   (except that you can skip this step).
 
 #. Partition your disk(s):
 

--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -209,7 +209,12 @@ Step 2: Disk Formatting
      sgdisk --zap-all $DISK
 
    If you get a message about the kernel still using the old partition table,
-   reboot and start over (except that you can skip this step).
+   you can request the kernel reload the partition information using::
+
+     partprobe $DISK
+
+   If the new partitions still don't show up, you can reboot and start over
+   (except that you can skip this step).
 
 #. Partition your disk(s):
 

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
@@ -324,7 +324,12 @@ Step 2: Disk Formatting
      sgdisk --zap-all $DISK
 
    If you get a message about the kernel still using the old partition table,
-   reboot and start over (except that you can skip this step).
+   you can request the kernel reload the partition information using::
+
+     partprobe $DISK
+
+   If the new partitions still don't show up, you can reboot and start over
+   (except that you can skip this step).
 
 #. Create bootloader partition(s)::
 

--- a/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS.rst
@@ -213,7 +213,12 @@ Step 2: Disk Formatting
      sgdisk --zap-all $DISK
 
    If you get a message about the kernel still using the old partition table,
-   reboot and start over (except that you can skip this step).
+   you can request the kernel reload the partition information using::
+
+     partprobe $DISK
+
+   If the new partitions still don't show up, you can reboot and start over
+   (except that you can skip this step).
 
 #. Create bootloader partition(s)::
 

--- a/docs/Getting Started/openSUSE/openSUSE Leap Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Leap Root on ZFS.rst
@@ -187,7 +187,12 @@ Step 2: Disk Formatting
      sgdisk --zap-all $DISK
 
    If you get a message about the kernel still using the old partition table,
-   reboot and start over (except that you can skip this step).
+   you can request the kernel reload the partition information using::
+
+     partprobe $DISK
+
+   If the new partitions still don't show up, you can reboot and start over
+   (except that you can skip this step).
 
 #. Partition your disk(s):
 

--- a/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
@@ -180,8 +180,12 @@ Step 2: Disk Formatting
      sgdisk --zap-all $DISK
 
    If you get a message about the kernel still using the old partition table,
-   reboot and start over (except that you can skip this step).
+   you can request the kernel reload the partition information using::
 
+     partprobe $DISK
+
+   If the new partitions still don't show up, you can reboot and start over
+   (except that you can skip this step).
 
 #. Partition your disk(s):
 


### PR DESCRIPTION
In almost all cases it is not necessary to reboot the machine in order
to reload the partition table for disks, you can just use partprobe(8)
which is part of parted and so is probably installed on all installation
media.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>