### PR TITLE
getting started: opensuse: mention zfs-ueficert package

### DIFF
--- a/docs/Getting Started/openSUSE/openSUSE Leap Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Leap Root on ZFS.rst
@@ -692,12 +692,26 @@ Step 5: System Configuration
 
    **Note:** If you installed `base` pattern, you need to deinstall busybox-grep to install `kernel-default` package.
 
-#. Install ZFS in the chroot environment for the new system::
+#. Install ZFS in the chroot environment for the new system
+
+   .. code-block:: text
 
      zypper install lsb-release
      zypper addrepo https://download.opensuse.org/repositories/filesystems/`lsb_release -rs`/filesystems.repo
      zypper refresh   # Refresh all repositories
      zypper install zfs zfs-kmp-default
+
+   Note that if your system uses UEFI with Secure Boot, since openSUSE Leap
+   15.2 the kernel requires all kernel modules to be signed. The ZFS kernel
+   module built in the ``filesystems`` project *is* signed, but not with the
+   official openSUSE key that was automatically registered with your system
+   when you first booted into openSUSE. In order to make sure that your system
+   trusts the ``filesystems`` signing key, make sure to install the
+   ``zfs-ueficert`` package as well::
+
+     zypper install zfs-ueficert
+
+   On the next boot, you will be prompted by the MOK to enroll the new key.
 
 #. For LUKS installs only, setup ``/etc/crypttab``::
 

--- a/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
@@ -677,12 +677,25 @@ Step 5: System Configuration
 
    .. note:: If you installed `base` pattern, you need to deinstall busybox-grep to install `kernel-default` package.
 
-#. Install ZFS in the chroot environment for the new system::
+#. Install ZFS in the chroot environment for the new system
+
+   .. code-block:: text
 
      zypper addrepo https://download.opensuse.org/repositories/filesystems/openSUSE_Tumbleweed/filesystems.repo
      zypper refresh   # Refresh all repositories
      zypper install zfs
 
+   Note that if your system uses UEFI with Secure Boot, since Linux 5.4 the
+   kernel requires all kernel modules to be signed. The ZFS kernel module built
+   in the ``filesystems`` project *is* signed, but not with the official
+   openSUSE key that was automatically registered with your system when you
+   first booted into openSUSE. In order to make sure that your system trusts
+   the ``filesystems`` signing key, make sure to install the ``zfs-ueficert``
+   package as well::
+
+     zypper install zfs-ueficert
+
+   On the next boot, you will be prompted by the MOK to enroll the new key.
 
 #. For LUKS installs only, setup ``/etc/crypttab``::
 


### PR DESCRIPTION
openSUSE enables kernel_lockdown(7), which forces all kernel modules to
need to be signed. The kernel module package building infrastructure
can sign all modules (and does for ZFS), but the module is not signed
with the official project keys (as it is managed by a devel project).

As per [1] the solution is to simply install zfs-ueficert which contains
the right signing key and also will auto-register the key with MOK on
the next boot.

[1]: https://bugzilla.suse.com/show_bug.cgi?id=1173551

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>