### PR TITLE
Add hint for Debian Bookworm ZFS Root Networking

### DIFF
--- a/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
@@ -565,6 +565,16 @@ Step 4: System Configuration
 
    Customize this file if the system is not a DHCP client.
 
+#. Optional: Install driver firmware and WiFi support
+
+   If you're installing on a laptop or a device where wireless is the
+   primary network option, the above may not be sufficient as you
+   could lack the appopriate firmware for the device and tools to
+   configure the radio. Install some additional packages to cover
+   that need::
+
+     apt install --yes firmware-linux wireless-tools
+
 #. Configure the package sources::
 
      vi /mnt/etc/apt/sources.list


### PR DESCRIPTION
Note that you may need to have appropriate firmware and networking utilities installed to have a working network upon reboot. This is varied so don't be overly specific but do point it out.