### PR TITLE
moving zgenhostid up - before dracut

### DIFF
--- a/docs/Getting Started/RHEL-based distro/Root on ZFS.rst
+++ b/docs/Getting Started/RHEL-based distro/Root on ZFS.rst
@@ -411,6 +411,10 @@ System Configuration
       echo 'filesystems+=" virtio_blk "' >> /etc/dracut.conf.d/zfs.conf
     fi
 
+#. Generate host id::
+
+    zgenhostid -f -o /etc/hostid
+
 #. Build initrd::
 
     find -D exec /lib/modules -maxdepth 1 \
@@ -424,10 +428,6 @@ System Configuration
 #. For SELinux, relabel filesystem on reboot::
 
     fixfiles -F onboot
-
-#. Generate host id::
-
-    zgenhostid -f -o /etc/hostid
 
 #. Install locale package, example for English locale::
 


### PR DESCRIPTION
we need to generate hostid before creating initramfs image, otherwise, you may receive the following warning when importing your pool as root:
```
$ sudo zpool status
  pool: rpool
 state: ONLINE
status: Mismatch between pool hostid and system hostid on imported pool.
	This pool was previously imported into a system with a different hostid,
	and then was verbatim imported into this system.
action: Export this pool on all systems on which it is imported.
	Then import it to correct the mismatch.
   see: https://openzfs.github.io/openzfs-docs/msg/ZFS-8000-EY
config:

	NAME        STATE     READ WRITE CKSUM
	rpool       ONLINE       0     0     0
	  sda3      ONLINE       0     0     0

errors: No known data errors
```