### PR TITLE
fix: arc_default_max (zfs_arc_max) on Linux matches FreeBSD as of zfs-2.3.0

### DIFF
--- a/docs/Performance and Tuning/Module Parameters.rst
+++ b/docs/Performance and Tuning/Module Parameters.rst
@@ -2372,6 +2372,10 @@ Maximum size of ARC in bytes.
 If set to 0 then the maximum size of ARC
 is determined by the amount of system memory installed:
 
+* **Linux** and **FreeBSD**: the larger of ``all_system_memory - 1GB`` and ``5/8 × all_system_memory``
+
+*prior to v2.3.0*
+
 * **Linux**: 1/2 of system memory
 * **FreeBSD**: the larger of ``all_system_memory - 1GB`` and ``5/8 × all_system_memory``
 


### PR DESCRIPTION
This change was made in [#15437](https://github.com/openzfs/zfs/pull/15437) and has been active as of zfs-2.3.0. 

I'm not sure the convention for dealing with behavior changes between ZFS versions in docs, so I left the pre-v2.3.0 behavior listed, and notated it as such. Let me know if I should remove it.