### PR TITLE
Debian: Update for trixie-backports

### DIFF
--- a/docs/Getting Started/Debian/index.rst
+++ b/docs/Getting Started/Debian/index.rst
@@ -19,12 +19,15 @@ often provides newer releases of ZFS. You can use it as follows.
 
 Add the backports repository::
 
-  vi /etc/apt/sources.list.d/bookworm-backports.list
+  vi /etc/apt/sources.list.d/trixie-backports.sources
 
 .. code-block:: sourceslist
 
-   deb http://deb.debian.org/debian bookworm-backports main contrib
-   deb-src http://deb.debian.org/debian bookworm-backports main contrib
+   Types: deb
+   URIs: https://deb.debian.org/debian
+   Suites: trixie-backports
+   Components: main contrib non-free non-free-firmware
+   Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 
 ::
 
@@ -33,8 +36,8 @@ Add the backports repository::
 .. code-block:: control
 
   Package: src:zfs-linux
-  Pin: release n=bookworm-backports
-  Pin-Priority: 990
+  Pin: release n=trixie-backports
+  Pin-Priority: 500
 
 Install the packages::
 


### PR DESCRIPTION
This needs to be tested.

The change from 500 to 990 may be incorrect. Looking at the apt_preferences docs again, actually 990 is used if a “target release” is set. So I’d have to test that some more. If you don’t have a “target release”, then 500 is the default and 500 here would be fine. But if your target release is trixie or stable, then the backport might lose. It depends on which field that is matching and how that field is set in backports.