### PR TITLE
Use zfs-release-3-0 RPM in install instructions

### DIFF
--- a/docs/Getting Started/Fedora/index.rst
+++ b/docs/Getting Started/Fedora/index.rst
@@ -24,9 +24,9 @@ see below.
 
 #. Add ZFS repo::
 
-    dnf install -y https://zfsonlinux.org/fedora/zfs-release-2-8$(rpm --eval "%{dist}").noarch.rpm
+    dnf install -y https://zfsonlinux.org/fedora/zfs-release-3-0$(rpm --eval "%{dist}").noarch.rpm
 
-   List of repos is available `here <https://github.com/zfsonlinux/zfsonlinux.github.com/tree/master/fedora>`__.
+   List of old zfs-release RPMs are available `here <https://github.com/zfsonlinux/zfsonlinux.github.com/tree/master/fedora>`__.
 
 #. Install kernel headers::
 

--- a/docs/Getting Started/RHEL-based distro/index.rst
+++ b/docs/Getting Started/RHEL-based distro/index.rst
@@ -41,7 +41,7 @@ For EL 7 run::
 
 and for EL 8-10::
 
- dnf install https://zfsonlinux.org/epel/zfs-release-2-8$(rpm --eval "%{dist}").noarch.rpm
+ dnf install https://zfsonlinux.org/epel/zfs-release-3-0$(rpm --eval "%{dist}").noarch.rpm
 
 After installing the *zfs-release* package and verifying the public key
 users can opt to install either the DKMS or kABI-tracking kmod style packages.


### PR DESCRIPTION
Use the zfs-release-3-0 RPM instead of zfs-release-2-8.  This is needed for Fedora 43.