### PR TITLE
Sort package list; add missing libtirpc-dev.

### DIFF
--- a/docs/Developer Resources/Custom Packages.rst
+++ b/docs/Developer Resources/Custom Packages.rst
@@ -212,7 +212,7 @@ Make sure that the required packages are installed:
 
 .. code:: sh
 
-   sudo apt install build-essential autoconf automake libtool gawk alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev libattr1-dev libelf-dev linux-headers-generic python3 python3-dev python3-setuptools python3-cffi libffi-dev python3-packaging debhelper-compat dh-python po-debconf python3-all-dev python3-sphinx libpam0g-dev
+   sudo apt install alien autoconf automake build-essential debhelper-compat dh-python dkms fakeroot gawk libaio-dev libattr1-dev libblkid-dev libelf-dev libffi-dev libpam0g-dev libssl-dev libtirpc-dev libtool libudev-dev linux-headers-generic po-debconf python3 python3-all-dev python3-cffi python3-dev python3-packaging python3-setuptools python3-sphinx uuid-dev zlib1g-dev
 
 `Get the source code <#get-the-source-code>`__.
 


### PR DESCRIPTION
Building on Trixie I noted that libtirpc-dev is required.

Also, package order passed to apt is irrelevant, so I sorted the list.