### PR TITLE
Amend Debian package install command; update for Trixie.

### DIFF
--- a/docs/Developer Resources/Custom Packages.rst
+++ b/docs/Developer Resources/Custom Packages.rst
@@ -212,7 +212,7 @@ Make sure that the required packages are installed:
 
 .. code:: sh
 
-   sudo apt install alien autoconf automake build-essential debhelper-compat dh-python dkms fakeroot gawk libaio-dev libattr1-dev libblkid-dev libelf-dev libffi-dev libpam0g-dev libssl-dev libtirpc-dev libtool libudev-dev linux-headers-generic po-debconf python3 python3-all-dev python3-cffi python3-dev python3-packaging python3-setuptools python3-sphinx uuid-dev zlib1g-dev
+   sudo apt install alien autoconf automake build-essential debhelper-compat dh-dkms dh-python dkms fakeroot gawk libaio-dev libattr1-dev libblkid-dev libcurl4-openssl-dev libelf-dev libffi-dev libpam0g-dev libssl-dev libtirpc-dev libtool libudev-dev linux-headers-generic po-debconf python3 python3-all-dev python3-cffi python3-dev python3-packaging python3-setuptools python3-sphinx uuid-dev zlib1g-dev
 
 `Get the source code <#get-the-source-code>`__.
 


### PR DESCRIPTION
Building on Trixie I noted that dh-dkms, libcurl4-openssl-dev, and
libtirpc-dev are required.

Also, package order passed to apt is irrelevant, so I sorted the list for 
easier consumption by humans.