### PR TITLE
Show individual `Last updated on` per page + fix copyright year

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,8 @@ import sphinx_rtd_theme  # noqa
 # -- Project information -----------------------------------------------------
 
 project = u'OpenZFS'
-copyright = u'2023, OpenZFS'
+copyright = u'%Y, OpenZFS'
+html_last_updated_fmt = ''
 author = u'OpenZFS'
 
 # The short X.Y version
@@ -51,6 +52,7 @@ extensions = [
     "sphinx_rtd_theme",
     "notfound.extension",
     "sphinxext.rediraffe",
+    "sphinx_last_updated_by_git",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,5 @@ sphinx-issues
 sphinx-notfound-page>=0.5
 sphinx-rtd-theme
 sphinxext-rediraffe
+sphinx_last_updated_by_git
 gitpython


### PR DESCRIPTION
Example: `© Copyright 2025, OpenZFS. Last updated on Nov 11, 2025. `

Note: generated pages like man pages won't have `Last updated` note.