### PR TITLE
RTD redirect: fix 404 redirects

### DIFF
--- a/docs/404.rst
+++ b/docs/404.rst
@@ -4,3 +4,14 @@
 ===================
 
 Please use left menu or search to find interested page.
+
+.. raw:: html
+
+   <script>
+
+.. raw:: html
+   :file: ./_static/js/redirect.js
+
+.. raw:: html
+
+   </script>


### PR DESCRIPTION
Now 404 uses static url prefix, rtd doesn't
have this prefix, so links like
https://openzfs.readthedocs.io/openzfs-docs/Getting%20Started/index.html (which existed in old rtd site)
can't load js with redirects.

So, just push redirect js inside 404 html page.