### PR TITLE
Debian Trixie updates

### DIFF
--- a/docs/Getting Started/Debian/Debian Trixie Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Trixie Root on ZFS.rst
@@ -1001,6 +1001,7 @@ Step 8: Full Software Installation
 
 #. Install a regular set of software::
 
+     apt install tasksel
      tasksel --new-install
 
    **Note:** This will check "Debian desktop environment" and "print server"


### PR DESCRIPTION
Hi @rlaager ,  I updated the debian trixie documentation with 3 issues I faced:

- You need to install kernel headers or the dkms zfs module will fail to build
- tmpfs is used by default so all /tmp stuff is obsolete
- tasksel is not installed by default now by debootstrap