### PR TITLE
Remove unnecessary "do" from Notes

### DIFF
--- a/docs/Basic Concepts/Checksums.rst
+++ b/docs/Basic Concepts/Checksums.rst
@@ -45,7 +45,7 @@ The checksum algorithm for a dataset can be changed by setting the
 |           |              |                        | deduped                 |
 |           |              |                        | datasets                |
 +-----------+--------------+------------------------+-------------------------+
-| off       | no           | yes                    | Do not do use           |
+| off       | no           | yes                    | Do not use              |
 |           |              |                        | ``off``                 |
 +-----------+--------------+------------------------+-------------------------+
 | fletcher2 | no           | yes                    | Deprecated              |


### PR DESCRIPTION
Remove the unnecessary word "do" from the notes, to make the recommendation to not use `off` obvious.