### PR TITLE
adding sitemap.xml, llms.txt, and llms-full.txt

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,7 @@ extensions = [
     "sphinxext.rediraffe",
     "sphinx_last_updated_by_git",
     "sphinx_sitemap",
+    "sphinx_llms_txt",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,3 +6,4 @@ sphinxext-rediraffe
 sphinx_last_updated_by_git
 gitpython
 sphinx-sitemap
+sphinx_llms_txt


### PR DESCRIPTION
This PR adds a sitemap and llms.txt support in separate commits.

`sitemap.xml` is useful for search engine crawlers. We want the docs to be easily indexed by search engines to improve ranking etc.

`llms.txt`/`llms-full.txt` are useful for llm crawlers. We want LLMs to be as accurate as possible when asked about OpenZFS, so let's make it easy for them to read the OpenZFS documentation we maintain. This should help the info from the docs site to be ingested into future models.

I've attached the 3 newly generated files to this PR for examination:
[llms.txt](https://github.com/user-attachments/files/24500254/llms.txt)
[llms-full.txt](https://github.com/user-attachments/files/24500255/llms-full.txt)
[sitemap.xml](https://github.com/user-attachments/files/24500256/sitemap.xml)

