### PR TITLE
Fix typo in Raspberry Pi ZFS bootloader instructions

### DIFF
--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS for Raspberry Pi.rst
@@ -142,7 +142,7 @@ do not apply to microSD cards:
    - Download the `Raspberry Pi Imager Utility
      <https://www.raspberrypi.com/news/raspberry-pi-imager-imaging-utility/>`_.
    - Flash the ``USB Boot`` image to a microSD card. The ``USB Boot`` image is
-     listed under ``Bootload`` in the ``Misc utility images`` folder.
+     listed under ``Bootloader`` in the ``Misc utility images`` folder.
    - Boot the Raspberry Pi from the microSD card. USB Boot should be enabled
      automatically.
 

--- a/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS for Raspberry Pi.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS for Raspberry Pi.rst
@@ -139,7 +139,7 @@ do not apply to microSD cards:
    - Download the `Raspberry Pi Imager Utility
      <https://www.raspberrypi.com/news/raspberry-pi-imager-imaging-utility/>`_.
    - Flash the ``USB Boot`` image to a microSD card. The ``USB Boot`` image is
-     listed under ``Bootload`` in the ``Misc utility images`` folder.
+     listed under ``Bootloader`` in the ``Misc utility images`` folder.
    - Boot the Raspberry Pi from the microSD card. USB Boot should be enabled
      automatically.
 


### PR DESCRIPTION
Corrected 'Bootload' to 'Bootloader' in the instructions for flashing the USB Boot image in both Ubuntu 20.04 and 22.04 ZFS setup guides for Raspberry Pi.

<img width="696" height="465" alt="{X67%@Y@_9X5~J8@B6O`TMT" src="https://github.com/user-attachments/assets/1ce9dda9-5c73-4d9f-9b2f-0664a03888ce" />
