### PR TITLE
Fix rendering issue where -- was displayed as a single en dash (–)

### DIFF
--- a/docs/Developer Resources/Custom Packages.rst
+++ b/docs/Developer Resources/Custom Packages.rst
@@ -122,7 +122,7 @@ Linux kernel must be specified. At configure time the build system will
 make an educated guess as to which kernel you want to build against.
 However, if configure is unable to locate your kernel development
 headers, or you want to build against a different kernel, you must
-specify the exact path with the *--with-linux* and *--with-linux-obj*
+specify the exact path with the ``--with-linux`` and ``--with-linux-obj``
 options.
 
 .. code:: sh
@@ -146,7 +146,7 @@ kABI-tracking kmod
 The process for building kABI-tracking kmods is almost identical to for
 building normal kmods. However, it will only produce binaries which can
 be used by multiple kernels if the distribution supports a stable kABI.
-In order to request kABI-tracking package the *--with-spec=redhat*
+In order to request kABI-tracking package the ``--with-spec=redhat``
 option must be passed to configure.
 
 Be aware that these packages do not completely follow Redhat's rules, so
@@ -235,7 +235,7 @@ Linux kernel must be specified. At configure time the build system will
 make an educated guess as to which kernel you want to build against.
 However, if configure is unable to locate your kernel development
 headers, or you want to build against a different kernel, you must
-specify the exact path with the *--with-linux* and *--with-linux-obj*
+specify the exact path with the ``--with-linux`` and ``--with-linux-obj``
 options.
 
 To build RPM converted Debian packages:


### PR DESCRIPTION
This commit ensures double hyphens are preserved correctly and no longer rendered as an en dash in the webpag output

<img width="591" height="275" alt="fa4172d15f30b49333b8c161aa2df0e4" src="https://github.com/user-attachments/assets/0f09fb2c-be53-4e35-8779-9e394b89e1df" />

<img width="1471" height="221" alt="f46525e3261b64cdef2b6ac85f3e9b82" src="https://github.com/user-attachments/assets/29697812-4b54-4721-a6d3-d13825365fa8" />

<img width="301" height="131" alt="OGDPIDJL8BM )CX70F EJLB" src="https://github.com/user-attachments/assets/8274357b-311a-444a-966d-f287fe049272" />

<img width="352" height="261" alt="W )J~7%J 0G(~3BBSN%G3BI" src="https://github.com/user-attachments/assets/7ad3e073-a8ee-404e-8513-b42311031d0e" />
