### PR TITLE
ZFS-8000-9P: Update codeblock example

### DIFF
--- a/docs/msg/ZFS-8000-9P/index.rst
+++ b/docs/msg/ZFS-8000-9P/index.rst
@@ -49,7 +49,7 @@ Run ``zpool status -x`` to determine which pool has experienced errors:
 
 ::
 
-   # zpool status
+   # zpool status -x
      pool: test
     state: ONLINE
    status: One or more devices has experienced an unrecoverable error.  An


### PR DESCRIPTION
Hello! I was investigating ZFS-8000-9P on one of my pools, and noticed a small discrepancy between the instructions and the example on that page. This is a PR making those consistent. Thanks!

Commit message:

The instructions in the document say to use "zpool status -x", but the codeblock example below it doesn't use "-x".

Update the codeblock to be consistent with the instructions.