### PR TITLE
Fix dead tarball URL and http→https in message example

### DIFF
--- a/docs/Developer Resources/Custom Packages.rst
+++ b/docs/Developer Resources/Custom Packages.rst
@@ -304,7 +304,7 @@ then use the following commands to fetch and prepare the source.
 
 .. code:: sh
 
-   $ wget http://archive.zfsonlinux.org/downloads/zfsonlinux/zfs/zfs-x.y.z.tar.gz
+   $ wget https://github.com/openzfs/zfs/releases/download/zfs-x.y.z/zfs-x.y.z.tar.gz
    $ tar -xzf zfs-x.y.z.tar.gz
 
 Git Master Branch

--- a/docs/msg/ZFS-8000-ER/index.rst
+++ b/docs/msg/ZFS-8000-ER/index.rst
@@ -281,7 +281,7 @@ the restrictions on raw sends.
            any existing encrypted datasets to new encrypted datasets and
            destroy the old ones. If this pool does not contain any
            encrypted datasets, simply enable the bookmark_v2 feature.
-      see: http://openzfs.github.io/openzfs-docs/msg/ZFS-8000-ER
+      see: https://openzfs.github.io/openzfs-docs/msg/ZFS-8000-ER
      scan: none requested
    config:
 


### PR DESCRIPTION
## Summary

- `Custom Packages.rst` pointed to `archive.zfsonlinux.org`, which no longer responds. Updated to the current GitHub Releases URL.
- `msg/ZFS-8000-ER/index.rst` example showed an `http://` self-reference; `zpool` itself prints `https://` today. Updated to match.

## Testing 

- [x] No build regressions (Sphinx-only changes)
- [x] Verified the new tarball URL resolves
- [x] Verified the `https://` form matches what `cmd/zpool/zpool_main.c` prints