### PR TITLE
Add Secure Boot warning to Debian, Ubuntu, and NixOS root guides

### DIFF
--- a/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
@@ -104,6 +104,7 @@ encrypted once per disk.
 Step 1: Prepare The Install Environment
 ---------------------------------------
 
+#. Disable Secure Boot. ZFS modules can not be loaded if Secure Boot is enabled.
 #. Boot the Debian GNU/Linux Live CD. If prompted, login with the username
    ``user`` and password ``live``. Connect your system to the Internet as
    appropriate (e.g. join your WiFi network). Open a terminal.

--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -104,6 +104,7 @@ encrypted once per disk.
 Step 1: Prepare The Install Environment
 ---------------------------------------
 
+#. Disable Secure Boot. ZFS modules can not be loaded if Secure Boot is enabled.
 #. Boot the Debian GNU/Linux Live CD. If prompted, login with the username
    ``user`` and password ``live``. Connect your system to the Internet as
    appropriate (e.g. join your WiFi network). Open a terminal.

--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -103,6 +103,7 @@ encrypted once per disk.
 Step 1: Prepare The Install Environment
 ---------------------------------------
 
+#. Disable Secure Boot. ZFS modules can not be loaded if Secure Boot is enabled.
 #. Boot the Debian GNU/Linux Live CD. If prompted, login with the username
    ``user`` and password ``live``. Connect your system to the Internet as
    appropriate (e.g. join your WiFi network). Open a terminal.

--- a/docs/Getting Started/Debian/Debian Trixie Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Trixie Root on ZFS.rst
@@ -96,6 +96,7 @@ encrypted once per disk.
 Step 1: Prepare The Install Environment
 ---------------------------------------
 
+#. Disable Secure Boot. ZFS modules can not be loaded if Secure Boot is enabled.
 #. Boot the Debian GNU/Linux Live CD. If prompted, login with the username
    ``user`` and password ``live``. Connect your system to the Internet as
    appropriate (e.g. join your WiFi network). Open a terminal.

--- a/docs/Getting Started/NixOS/Root on ZFS.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS.rst
@@ -28,6 +28,7 @@ booted in UEFI mode.
 Preparation
 ---------------------------
 
+#. Disable Secure Boot. ZFS modules can not be loaded if Secure Boot is enabled.
 #. Download `NixOS Live Image
    <https://nixos.org/download.html#nixos-iso>`__ and boot from it.
 

--- a/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 20.04 Root on ZFS.rst
@@ -232,6 +232,7 @@ encrypted once per disk.
 Step 1: Prepare The Install Environment
 ---------------------------------------
 
+#. Disable Secure Boot. ZFS modules can not be loaded if Secure Boot is enabled.
 #. Boot the Ubuntu Live CD. Select Try Ubuntu. Connect your system to the
    Internet as appropriate (e.g. join your WiFi network). Open a terminal
    (press Ctrl-Alt-T).

--- a/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS.rst
+++ b/docs/Getting Started/Ubuntu/Ubuntu 22.04 Root on ZFS.rst
@@ -111,6 +111,7 @@ encrypted once per disk.
 Step 1: Prepare The Install Environment
 ---------------------------------------
 
+#. Disable Secure Boot. ZFS modules can not be loaded if Secure Boot is enabled.
 #. Boot the Ubuntu Live CD. From the GRUB boot menu, select *Try or Install Ubuntu*.
    On the *Welcome* page, select your preferred language and *Try Ubuntu*.
    Connect your system to the Internet as appropriate (e.g. join your WiFi network).


### PR DESCRIPTION
Other Root-on-ZFS guides already note that ZFS modules cannot load with Secure Boot enabled (Fedora, Alpine, RHEL-based, Arch). The Debian,Ubuntu, and NixOS guides did not.

Closes #493

Signed-off-by: Christos Longros <chris.longros@gmail.com>