### PR TITLE
Debian: move optional WiFi/firmware step into the chroot + misc

### DIFF
--- a/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
@@ -573,16 +573,6 @@ Step 4: System Configuration
 
    Customize this file if the system is not a DHCP client.
 
-#. Optional: Install driver firmware and WiFi support
-
-   If you're installing on a laptop or a device where wireless is the
-   primary network option, the above may not be sufficient as you
-   could lack the appropriate firmware for the device and tools to
-   configure the radio. Install some additional packages to cover
-   that need::
-
-     apt install --yes firmware-linux wireless-tools
-
 #. Configure the package sources::
 
      vi /mnt/etc/apt/sources.list
@@ -618,6 +608,16 @@ Step 4: System Configuration
    ``en_US.UTF-8`` is available::
 
      dpkg-reconfigure locales tzdata keyboard-configuration console-setup
+
+#. Optional: Install driver firmware and WiFi support
+
+   If you're installing on a laptop or a device where wireless is the
+   primary network option, the network configuration above may not be
+   sufficient as you could lack the appropriate firmware for the device
+   and tools to configure the radio. Install some additional packages to
+   cover that need::
+
+     apt install --yes firmware-linux wireless-tools
 
 #. Install ZFS in the chroot environment for the new system::
 

--- a/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
@@ -798,7 +798,7 @@ Step 4: System Configuration
 
 #. Optional (but kindly requested): Install popcon
 
-   The ``popularity-contest`` package reports the list of packages install
+   The ``popularity-contest`` package reports the list of packages installed
    on your system. Showing that ZFS is popular may be helpful in terms of
    long-term attention from the distro.
 

--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -829,7 +829,7 @@ Step 4: System Configuration
 
 #. Optional (but kindly requested): Install popcon
 
-   The ``popularity-contest`` package reports the list of packages install
+   The ``popularity-contest`` package reports the list of packages installed
    on your system. Showing that ZFS is popular may be helpful in terms of
    long-term attention from the distro.
 

--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -769,7 +769,7 @@ Step 4: System Configuration
 
 #. Optional (but kindly requested): Install popcon
 
-   The ``popularity-contest`` package reports the list of packages install
+   The ``popularity-contest`` package reports the list of packages installed
    on your system. Showing that ZFS is popular may be helpful in terms of
    long-term attention from the distro.
 

--- a/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
@@ -617,7 +617,7 @@ tmpfs (RAM filesystem) by enabling the ``tmp.mount`` unit.
 
 4.12 Optional (but kindly requested): Install popcon
 
-The ``popularity-contest`` package reports the list of packages install
+The ``popularity-contest`` package reports the list of packages installed
 on your system. Showing that ZFS is popular may be helpful in terms of
 long-term attention from the distro.
 

--- a/docs/Getting Started/Debian/Debian Trixie Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Trixie Root on ZFS.rst
@@ -635,7 +635,7 @@ Step 4: System Configuration
    Although this step is not necessary for ZFS, it is useful for internet
    browsing where local clock drift can cause login failures::
 
-     apt install systemd-timesyncd
+     apt install --yes systemd-timesyncd
 
 #. Install GRUB
 
@@ -648,7 +648,7 @@ Step 4: System Configuration
 
    - Install GRUB for UEFI booting::
 
-        apt install dosfstools
+        apt install --yes dosfstools
 
         mkdosfs -F 32 -s 1 -n EFI ${DISK}-part2
         mkdir /boot/efi
@@ -771,7 +771,7 @@ Step 4: System Configuration
 
 #. Optional (but kindly requested): Install popcon
 
-   The ``popularity-contest`` package reports the list of packages install
+   The ``popularity-contest`` package reports the list of packages installed
    on your system. Showing that ZFS is popular may be helpful in terms of
    long-term attention from the distro.
 
@@ -1005,7 +1005,7 @@ Step 8: Full Software Installation
 
 #. Install a regular set of software::
 
-     apt install tasksel
+     apt install --yes tasksel
      tasksel --new-install
 
    **Note:** This will check "Debian desktop environment" and "print server"

--- a/docs/Getting Started/Debian/Debian Trixie Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Trixie Root on ZFS.rst
@@ -553,16 +553,6 @@ Step 4: System Configuration
 
    Customize this file if the system is not a DHCP client.
 
-#. Optional: Install driver firmware and WiFi support
-
-   If you're installing on a laptop or a device where wireless is the
-   primary network option, the above may not be sufficient as you
-   could lack the appropriate firmware for the device and tools to
-   configure the radio. Install some additional packages to cover
-   that need::
-
-     apt install --yes firmware-linux wireless-tools
-
 #. Configure the package sources::
 
      vi /mnt/etc/apt/sources.list
@@ -598,6 +588,16 @@ Step 4: System Configuration
    ``en_US.UTF-8`` is available::
 
      dpkg-reconfigure locales tzdata keyboard-configuration console-setup
+
+#. Optional: Install driver firmware and WiFi support
+
+   If you're installing on a laptop or a device where wireless is the
+   primary network option, the network configuration above may not be
+   sufficient as you could lack the appropriate firmware for the device
+   and tools to configure the radio. Install some additional packages to
+   cover that need::
+
+     apt install --yes firmware-linux wireless-tools
 
 #. Install ZFS in the chroot environment for the new system::
 

--- a/docs/Getting Started/Debian/Debian Trixie Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Trixie Root on ZFS.rst
@@ -597,7 +597,11 @@ Step 4: System Configuration
    and tools to configure the radio. Install some additional packages to
    cover that need::
 
-     apt install --yes firmware-linux wireless-tools
+     apt install --yes firmware-linux iw wpasupplicant
+
+   ``wpasupplicant`` is required to join WPA-protected networks. If you
+   install a desktop environment later, NetworkManager will take over the
+   configuration of the radio.
 
 #. Install ZFS in the chroot environment for the new system::
 


### PR DESCRIPTION
The 'Install driver firmware and WiFi support' step ran 'apt install' while still in the live environment, so the packages landed in (or were already present in) the live system instead of the target system.

Move it after 'Configure a basic system environment', which is inside the chroot but still before the live CD environment is left, so the live CD's WiFi drivers remain available.

Applies to both Bookworm and Trixie guides.

Closes: #635