### PR TITLE
Link inwards instead of out, and raise Basic Concepts in the menu

### DIFF
--- a/docs/Basic Concepts/Operations/Troubleshooting.rst
+++ b/docs/Basic Concepts/Operations/Troubleshooting.rst
@@ -217,7 +217,7 @@ only once the deadman timer expires.
 
 **ZFS debug messages.** The modules keep an internal log buffer, readable at
 ``/proc/spl/kstat/zfs/dbgmsg``, when the module parameter
-`zfs_dbgmsg_enable <https://openzfs.github.io/openzfs-docs/Performance%20and%20Tuning/Module%20Parameters.html#zfs-dbgmsg-enable>`__
+`zfs_dbgmsg_enable <../../Performance and Tuning/Module Parameters.html#zfs-dbgmsg-enable>`__
 is 1. This is frequently what developers ask for.
 
 **Per-pool I/O statistics.** ``/proc/spl/kstat/zfs/<pool>/`` on Linux.
@@ -252,7 +252,7 @@ and take action. The script usually installed at
    zpool events -f                 # follow
 
 The history lives in RAM and is capped by
-`zfs_zevent_len_max <https://openzfs.github.io/openzfs-docs/Performance%20and%20Tuning/Module%20Parameters.html#zfs-zevent-len-max>`__.
+`zfs_zevent_len_max <../../Performance and Tuning/Module Parameters.html#zfs-zevent-len-max>`__.
 ``zed`` throttles internally so a failing device cannot exhaust the system.
 
 Each event carries a class used for filtering:

--- a/docs/Basic Concepts/Pool Structure/dRAID Howto.rst
+++ b/docs/Basic Concepts/Pool Structure/dRAID Howto.rst
@@ -245,4 +245,4 @@ state.
 .. |draid-resilver| image:: /_static/img/draid-resilver-hours.png
 .. _dRAID: https://docs.google.com/presentation/d/1uo0nBfY84HIhEqGWEx-Tbm8fPbJKtIP3ICo4toOPcJo/edit
 .. _sequential resilver: https://docs.google.com/presentation/d/1vLsgQ1MaHlifw40C9R2sPsSiHiQpxglxMbK2SMthu0Q/edit#slide=id.g995720a6cf_1_39
-.. _custom packages: https://openzfs.github.io/openzfs-docs/Developer%20Resources/Custom%20Packages.html#
+.. _custom packages: ../../Developer Resources/Custom Packages.html

--- a/docs/Developer Resources/Git and GitHub for beginners.rst
+++ b/docs/Developer Resources/Git and GitHub for beginners.rst
@@ -55,8 +55,7 @@ From here you can make your changes and move on to the next step.
 
 Recommended reading: `C Style and Coding Standards for
 SunOS <https://www.cis.upenn.edu/~lee/06cse480/data/cstyle.ms.pdf>`__,
-`ZFS on Linux Developer
-Resources <https://openzfs.github.io/openzfs-docs/Developer%20Resources/>`__,
+:doc:`OpenZFS Developer Resources </Developer Resources/index>`,
 `OpenZFS Developer
 Resources <https://openzfs.org/wiki/Developer_resources>`__
 
@@ -79,8 +78,7 @@ correctly.
    ./configure
    make checkstyle
 
-Recommended reading: `Building
-ZFS <https://openzfs.github.io/openzfs-docs/Developer%20Resources/Building%20ZFS.html>`__, `ZFS Test
+Recommended reading: :doc:`Building ZFS </Developer Resources/Building ZFS>`, `ZFS Test
 Suite
 README <https://github.com/openzfs/zfs/blob/master/tests/README.md>`__
 

--- a/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
@@ -29,8 +29,7 @@ System Requirements
 
 - `64-bit Debian GNU/Linux Bookworm Live CD w/ GUI (e.g. gnome iso)
   <https://cdimage.debian.org/mirror/cdimage/release/current-live/amd64/iso-hybrid/>`__
-- `A 64-bit kernel is strongly encouraged.
-  <https://openzfs.github.io/openzfs-docs/Project%20and%20Community/FAQ.html#bit-vs-64-bit-systems>`__
+- :ref:`A 64-bit kernel is strongly encouraged. <32-bit-vs-64-bit-systems>`
 - Installing on a drive which presents 4 KiB logical sectors (a “4Kn” drive)
   only works with UEFI booting. This is not unique to ZFS. `GRUB does not and
   will not work on 4Kn with legacy (BIOS) booting.

--- a/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bullseye Root on ZFS.rst
@@ -29,8 +29,7 @@ System Requirements
 
 - `64-bit Debian GNU/Linux Bullseye Live CD w/ GUI (e.g. gnome iso)
   <https://cdimage.debian.org/mirror/cdimage/release/current-live/amd64/iso-hybrid/>`__
-- `A 64-bit kernel is strongly encouraged.
-  <https://openzfs.github.io/openzfs-docs/Project%20and%20Community/FAQ.html#bit-vs-64-bit-systems>`__
+- :ref:`A 64-bit kernel is strongly encouraged. <32-bit-vs-64-bit-systems>`
 - Installing on a drive which presents 4 KiB logical sectors (a “4Kn” drive)
   only works with UEFI booting. This not unique to ZFS. `GRUB does not and
   will not work on 4Kn with legacy (BIOS) booting.

--- a/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Buster Root on ZFS.rst
@@ -28,8 +28,7 @@ System Requirements
 
 - `64-bit Debian GNU/Linux Buster Live CD w/ GUI (e.g. gnome iso)
   <https://cdimage.debian.org/mirror/cdimage/release/current-live/amd64/iso-hybrid/>`__
-- `A 64-bit kernel is strongly encouraged.
-  <https://openzfs.github.io/openzfs-docs/Project%20and%20Community/FAQ.html#bit-vs-64-bit-systems>`__
+- :ref:`A 64-bit kernel is strongly encouraged. <32-bit-vs-64-bit-systems>`
 - Installing on a drive which presents 4 KiB logical sectors (a “4Kn” drive)
   only works with UEFI booting. This not unique to ZFS. `GRUB does not and
   will not work on 4Kn with legacy (BIOS) booting.

--- a/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Stretch Root on ZFS.rst
@@ -25,8 +25,7 @@ System Requirements
 
 - `64-bit Debian GNU/Linux Stretch Live
   CD <http://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/>`__
-- `A 64-bit kernel is strongly
-  encouraged. <https://openzfs.github.io/openzfs-docs/Project%20and%20Community/FAQ.html#bit-vs-64-bit-systems>`__
+- :ref:`A 64-bit kernel is strongly encouraged. <32-bit-vs-64-bit-systems>`
 - Installing on a drive which presents 4KiB logical sectors (a “4Kn”
   drive) only works with UEFI booting. This not unique to ZFS. `GRUB
   does not and will not work on 4Kn with legacy (BIOS)

--- a/docs/Getting Started/index.rst
+++ b/docs/Getting Started/index.rst
@@ -3,9 +3,13 @@ Getting Started
 
 To get started with OpenZFS refer to the provided documentation for your
 distribution. It will cover the recommended installation method and any
-distribution specific information. First time OpenZFS users are
-encouraged to check out Aaron Toponce's `excellent
-documentation <https://web.archive.org/web/20230904234829/https://pthree.org/2012/04/17/install-zfs-on-debian-gnulinux/>`__.
+distribution specific information.
+
+First time OpenZFS users should then read
+:doc:`Basic Concepts </Basic Concepts/index>`, starting with
+:doc:`Copy-on-Write </Basic Concepts/Copy-on-write>` and
+:doc:`VDEVs </Basic Concepts/Pool Structure/VDEVs>` — pool layout is the
+decision that is hardest to undo.
 
 .. toctree::
    :maxdepth: 3

--- a/docs/Getting Started/openSUSE/openSUSE Leap Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Leap Root on ZFS.rst
@@ -27,8 +27,7 @@ System Requirements
 
 - `64-bit openSUSE Leap Live CD w/ GUI (e.g. gnome iso)
   <https://software.opensuse.org/distributions/leap>`__
-- `A 64-bit kernel is strongly encouraged.
-  <https://openzfs.github.io/openzfs-docs/Project%20and%20Community/FAQ.html#bit-vs-64-bit-systems>`__
+- :ref:`A 64-bit kernel is strongly encouraged. <32-bit-vs-64-bit-systems>`
 - Installing on a drive which presents 4 KiB logical sectors (a “4Kn” drive)
   only works with UEFI booting. This not unique to ZFS. `GRUB does not and
   will not work on 4Kn with legacy (BIOS) booting.

--- a/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
+++ b/docs/Getting Started/openSUSE/openSUSE Tumbleweed Root on ZFS.rst
@@ -28,8 +28,7 @@ System Requirements
 
 - `64-bit openSUSE Tumbleweed Live CD w/ GUI (e.g. gnome iso)
   <https://software.opensuse.org/distributions/tumbleweed>`__
-- `A 64-bit kernel is strongly encouraged.
-  <https://openzfs.github.io/openzfs-docs/Project%20and%20Community/FAQ.html#bit-vs-64-bit-systems>`__
+- :ref:`A 64-bit kernel is strongly encouraged. <32-bit-vs-64-bit-systems>`
 - Installing on a drive which presents 4 KiB logical sectors (a “4Kn” drive)
   only works with UEFI booting. This not unique to ZFS. `GRUB does not and
   will not work on 4Kn with legacy (BIOS) booting.

--- a/docs/Performance and Tuning/Workload Tuning.rst
+++ b/docs/Performance and Tuning/Workload Tuning.rst
@@ -103,8 +103,7 @@ different workarounds. The platform-specific methods are as follows:
    on FreeBSD; see for example `FreeBSD on 4K sector
    drives <http://web.archive.org/web/20151022020605/http://ivoras.sharanet.org/blog/tree/2011-01-01.freebsd-on-4k-sector-drives.html>`__
    (2011-01-01)
--  `ashift= <https://openzfs.github.io/openzfs-docs/Project%20and%20Community/FAQ.html#advanced-format-disks>`__
-   on ZFS on Linux
+-  :ref:`ashift= <advanced-format-disks>` on ZFS on Linux
 -  -o ashift= also works with both MacZFS (pool version 8) and ZFS-OSX
    (pool version 5000).
 

--- a/docs/Performance and Tuning/ZIO Scheduler.rst
+++ b/docs/Performance and Tuning/ZIO Scheduler.rst
@@ -31,16 +31,16 @@ prioritized in the following order:
 +-----------+--------------+-------------------------------------------+-----------------+
 
 For interactive I/Os each queue defines the minimum and maximum number of concurrent
-operations issued to the device. Each device also respects an aggregate maximum - `zfs_vdev_max_active <https://openzfs.github.io/openzfs-docs/Performance%20and%20Tuning/Module%20Parameters.html#zfs-vdev-max-active>`_.
+operations issued to the device. Each device also respects an aggregate maximum - `zfs_vdev_max_active <../Performance and Tuning/Module Parameters.html#zfs-vdev-max-active>`_.
 Note that the sum of the per-queue minimums must not exceed the aggregate maximum.
 If the sum of the per-queue maximums exceeds the aggregate maximum, then the number of
-active I/Os may reach `zfs_vdev_max_active <https://openzfs.github.io/openzfs-docs/Performance%20and%20Tuning/Module%20Parameters.html#zfs-vdev-max-active>`_,
+active I/Os may reach `zfs_vdev_max_active <../Performance and Tuning/Module Parameters.html#zfs-vdev-max-active>`_,
 in which case no further I/Os are issued regardless of whether all per-queue minimums have been met.
 
 For non-interactive I/O (scrub, resilver, removal, initializing, and rebuild),
 the number of concurrently-active I/Os is limited to _min_active, unless
 the vdev is "idle". When there are no interactive I/Os active (sync or
-async), and `zfs_vdev_nia_delay <https://openzfs.github.io/openzfs-docs/Performance%20and%20Tuning/Module%20Parameters.html#zfs-vdev-nia-delay>`_
+async), and `zfs_vdev_nia_delay <../Performance and Tuning/Module Parameters.html#zfs-vdev-nia-delay>`_
 I/Os have completed since the last interactive I/O, then the vdev is considered to be "idle", and the number
 of concurrently-active non-interactive I/Os is increased to _max_active.
 
@@ -148,7 +148,7 @@ part of the function between zfs_vdev_async_write_active_min_dirty_percent
 and zfs_vdev_async_write_active_max_dirty_percent. If it exceeds the
 maximum percentage, this indicates that the rate of incoming data is
 greater than the rate that the backend storage can handle. In this case, we
-must further throttle incoming writes. See `ZIO Transaction Delay <https://openzfs.github.io/openzfs-docs/Performance%20and%20Tuning/ZFS%20Transaction%20Delay.html>`_ for details.
+must further throttle incoming writes. See :doc:`ZFS Transaction Delay </Performance and Tuning/ZFS Transaction Delay>` for details.
 
 
 

--- a/docs/Project and Community/FAQ.rst
+++ b/docs/Project and Community/FAQ.rst
@@ -529,6 +529,8 @@ practices you should follow. See also
    the pool. This tuning parameter can result in a decrease of capacity
    for RAIDZ configurations.
 
+.. _advanced-format-disks:
+
 Advanced Format Disks
 ---------------------
 

--- a/docs/_TableOfContents.rst
+++ b/docs/_TableOfContents.rst
@@ -3,10 +3,10 @@
    :glob:
 
    Getting Started/index
+   Basic Concepts/index
    Project and Community/index
    Developer Resources/index
    Performance and Tuning/index
-   Basic Concepts/index
    man/index
    msg/index
    License


### PR DESCRIPTION
Getting Started sent first-time users to a blog series archived in 2023 and last written in 2013. Point them at Basic Concepts instead, which is what that link was standing in for.

Thirteen links pointed at openzfs.github.io to reach pages in this same build. They leave the site and come back, break in a local or preview build, and make the weekly linkcheck fetch our own pages over the network. Replace them with :doc: and :ref: where a target exists, and with relative paths into the generated Module Parameters page, which has no labels to reference. Add the missing label the ashift entry in Workload Tuning was reaching for by URL.

The self-references left in msg/ are quoted zpool status output and have to stay verbatim.

Basic Concepts now moves to second in the menu, after Getting Started: it is where a reader goes once ZFS is installed, and it was sitting below three sections about the project rather than the software.