### PR TITLE
Debian: drop REMAKE_INITRD from the Bookworm and Trixie guides

### DIFF
--- a/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Bookworm Root on ZFS.rst
@@ -624,8 +624,6 @@ Step 4: System Configuration
 
      apt install --yes zfs-initramfs
 
-     echo REMAKE_INITRD=yes > /etc/dkms/zfs.conf
-
    **Note:** Ignore any error messages saying ``ERROR: Couldn't resolve
    device`` and ``WARNING: Couldn't determine root device``.  `cryptsetup does
    not support ZFS

--- a/docs/Getting Started/Debian/Debian Trixie Root on ZFS.rst
+++ b/docs/Getting Started/Debian/Debian Trixie Root on ZFS.rst
@@ -609,8 +609,6 @@ Step 4: System Configuration
 
      apt install --yes zfs-initramfs
 
-     echo REMAKE_INITRD=yes > /etc/dkms/zfs.conf
-
    **Note:** Ignore any error messages saying ``ERROR: Couldn't resolve
    device`` and ``WARNING: Couldn't determine root device``.  `cryptsetup does
    not support ZFS


### PR DESCRIPTION
The line was added in 417c2a5 for Buster, where dkms 2.6 really did rebuild the initrd itself: read_conf turned REMAKE_INITRD=yes into remake_initrd, and do_install then called make_initrd, which on Debian ran update-initramfs. Without it a kernel upgrade regenerated the initrd before the module had been built against the new kernel, and the system did not come back up.

dkms 3.0 deprecated the variable (dell/dkms#164) and took the initrd code out with it. All that is left of it is one line that prints "Deprecated feature: REMAKE_INITRD" and returns; nothing in dkms 3.x touches an initramfs at all. Bookworm ships 3.0.10 and Trixie ships 3.2.2, so on both the file we tell the reader to write buys them a warning on every dkms run and nothing else.

The ordering it was there to fix is now handled by the kernel hook dkms installs: run-parts walks /etc/kernel/postinst.d in name order, so dkms builds the module before initramfs-tools regenerates the initrd.

Bullseye and Buster keep the line: they ship dkms 2.8.4 and 2.6.1, where it still does its job.

Closes: openzfs/openzfs-docs#534