### PR TITLE
Warn that the ZFS Test Suite destroys pools, and stop suggesting -x

### DIFF
--- a/docs/Developer Resources/Building ZFS.rst
+++ b/docs/Developer Resources/Building ZFS.rst
@@ -154,7 +154,9 @@ the ZFS and SPL source in the traditional autotools fashion.
 Install
 ^^^^^^^
 
-You can run ``zfs-tests.sh`` without installing ZFS, see below. If you
+You can run ``zfs-tests.sh`` without installing ZFS, see
+:ref:`below <running-zloopsh-and-zfs-testssh>` - but read the warning there
+first, as the test suite is destructive. If you
 have reason to install ZFS after building it, pay attention to how your
 distribution handles kernel modules. On Ubuntu, for example, the modules
 from this repository install in the ``extra`` kernel module path, which
@@ -171,6 +173,13 @@ the kernel modules with ``sudo make -C modules/ install``.
 
 Running zloop.sh and zfs-tests.sh
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. danger::
+   These are developer tools for validating changes to OpenZFS, not a way
+   for end users to check an installation. They are destructive: they
+   create and destroy pools, load and unload the kernel modules, add users
+   and groups, and write to ``/var/tmp``. Run them only on a dedicated test
+   machine or VM, never on a system holding data you care about.
 
 If you wish to run the ZFS Test Suite (ZTS), then ``ksh`` and a few
 additional utilities must be installed.
@@ -250,7 +259,15 @@ directory designed to aid developers working with in-tree builds.
 
 ::
 
-    ./scripts/zfs-tests.sh -vx
+    ./scripts/zfs-tests.sh -v
+
+.. danger::
+   The **-x** option cleans up leftovers from a previous run by removing
+   test pools, device-mapper and loopback devices, and files. It cannot
+   always tell those apart from resources that have nothing to do with
+   testing, so it can destroy an unrelated pool - an exported one, or one
+   with no mounted datasets. Only use it on a machine dedicated to running
+   the test suite.
 
 **tip:** The **delegate** tests will be skipped unless group read
 permission is set on the zfs directory and its parents.


### PR DESCRIPTION
The page hands the reader ./scripts/zfs-tests.sh -vx with nothing said about what -x does. Upstream's tests/README.md is blunt about it: it "will attempt to remove any leftover configuration from a previous test run", and "this operation can be DANGEROUS because it is possible that the script will mistakenly remove a resource not related to the testing". A reporter took our line at face value and lost a pool that had no mounted datasets, which is exactly the case the cleanup cannot tell apart from its own leftovers.

Drop the x from the suggested command and say what the option does where someone about to type it will read it.

The larger problem is that nothing on the page frames these scripts as developer tools. Someone who has just built ZFS and wants to check the build reads "Running zloop.sh and zfs-tests.sh" as the way to do that, and the suite happily creates and destroys pools, loads and unloads the modules, and adds users and groups on the machine it finds itself on. Upstream asks for a dedicated machine or VM for that reason; say so at the top of the section, and point the "see below" in Install at it.

Both notes use danger rather than warning: in sphinx_rtd_theme that is the red one, and losing a pool earns the red one.

Closes: openzfs/openzfs-docs#646